### PR TITLE
issue-90:MaxInstanceLifetime vlaues adjusted in autoscaling groups

### DIFF
--- a/CloudFormationWindows/lansa-win-custom.cfn.template
+++ b/CloudFormationWindows/lansa-win-custom.cfn.template
@@ -662,6 +662,7 @@
                 "DesiredCapacity": "1",
                 "HealthCheckType": "ELB",
                 "HealthCheckGracePeriod": 2400,
+                "MaxInstanceLifetime": 5270400,
                 "LoadBalancerNames": [ { "Ref": "WebServerELB" } ],
                 "Tags": [
                     {
@@ -1367,6 +1368,7 @@
                 "DesiredCapacity": { "Ref": "18WebServerCapacity" },
                 "HealthCheckType": "ELB",
                 "HealthCheckGracePeriod": 2400,
+                "MaxInstanceLifetime": 5788800,
                 "LoadBalancerNames": [ { "Ref": "WebServerELB" } ],
                 "Tags": [
                     {

--- a/scripts/getchoco.ps1
+++ b/scripts/getchoco.ps1
@@ -277,7 +277,7 @@ try {
 choco feature enable --name=allowGlobalConfirmation | Out-Default | Write-Host
 choco source add -n=choco `
 -s="https://pkgs.dev.azure.com/VisualLansa/_packaging/choco/nuget/v2" `
--u="AzureDevOpsArtifacts@lansacloudlansacom.onmicrosoft.com" -p="ln65igsabq56drqml3vvcyxcldhdzdjcnvvqjvtuvoj34q4egllq"
+-u="AzureDevOpsArtifacts@lansacloudlansacom.onmicrosoft.com" -p="266tdaklo47lhxfvaz7pgqagpyz72uoeahjyg7mkpaxtwdzmkp6a"
 
 # update chocolatey to the latest version
 #Write-Host "Updating chocolatey to the latest version"


### PR DESCRIPTION
Hi @robe070 

**Step 1**: Added the parameters values in the autoscaling group in the file `Lansa-win-custom.cfn.template` for the DB and Web server. 
**Step 2**: Deploy the stack into AWS console and able to see the **MaxInstanceLifetime** as expected[61 and 67days]. 
Please find the attached screen shot for reference. 

<img width="691" alt="DB" src="https://user-images.githubusercontent.com/72967378/100869883-baab7d00-34c3-11eb-9363-6b513a4b9687.PNG">

<img width="724" alt="Web" src="https://user-images.githubusercontent.com/72967378/100869934-cc8d2000-34c3-11eb-90c4-502af51a68de.PNG">