### PR TITLE
Feature/priyanka classic2 yaml

### DIFF
--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -325,7 +325,7 @@ jobs:
       ConnectedServiceName: $(ConnectedServiceName)
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
-      resourceGroupName: BakingDP-w22d150$(VersionText-w22d-15-0)
+      resourceGroupName: BakingDP-w22d-15-0-$(VersionText-w22d-15-0)
 
 - job: Job_6
   displayName: 'Agent job : w16d-14-2'
@@ -494,7 +494,7 @@ jobs:
       ConnectedServiceName: $(ConnectedServiceName)
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
-      resourceGroupName: BakingDP-w16d142$(VersionText-w16d-14-2)
+      resourceGroupName: BakingDP-w16d-14-2-$(VersionText-w16d-14-2)
 
 - job: Job_4
   displayName: 'Agent job : w16d-15-0'
@@ -761,7 +761,7 @@ jobs:
     displayName: Azure Login
     inputs:
       filePath: scripts/AzureLogin.ps1
-      arguments: -CloudAccount $(azureUserId) -CloudSecret (ConvertTo-SecureString "$(clientSecret)" -AsPlainText -force)
+      arguments: -CloudAccount $(azureUserId) -CloudSecret (ConvertTo-SecureString $(clientSecret) -AsPlainText -force)
       workingDirectory: scripts
 
   - task: PowerShell@2
@@ -770,7 +770,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d-14-2$(VersionText-w19d-14-2)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w19d-14-2-$(VersionText-w19d-14-2)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -778,7 +778,7 @@ jobs:
     continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w19d142$(VersionText-w19d-14-2)
+      ResourceGroupName: BakingDP-w19d-14-2-$(VersionText-w19d-14-2)
       Key: Usage
       Value: test-temp
 
@@ -832,7 +832,7 @@ jobs:
       ConnectedServiceName: $(ConnectedServiceName)
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
-      resourceGroupName: BakingDP-w19d142$(VersionText-w19d-14-2)$(Build.BuildNumber)
+      resourceGroupName: BakingDP-w19d-14-2-$(VersionText-w19d-14-2)
 
 - job: Job_2
   displayName: 'Agent job : w19d-15-0'
@@ -939,7 +939,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d-15-0$(VersionText-w19d-15-0)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w19d-15-0-$(VersionText-w19d-15-0)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -947,7 +947,7 @@ jobs:
     continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w19d150$(VersionText-w19d-15-0)
+      ResourceGroupName: BakingDP-w19d-15-0-$(VersionText-w19d-15-0)
       Key: Usage
       Value: test-temp
 
@@ -1001,7 +1001,7 @@ jobs:
       ConnectedServiceName: $(ConnectedServiceName)
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
-      resourceGroupName: BakingDP-w19d150$(VersionText-w19d-15-0)
+      resourceGroupName: BakingDP-w19d-15-0-$(VersionText-w19d-15-0)
 
 - job: Job_7
   displayName: 'Agent job : w16d-14-2j'
@@ -1108,7 +1108,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w16d-14-2j$(VersionText-w16d-14-2j)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2016-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w16d-14-2j-$(VersionText-w16d-14-2j)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2016-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -1116,7 +1116,7 @@ jobs:
     continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w16d142j$(VersionText-w16d-14-2j)
+      ResourceGroupName: BakingDP-w16d-14-2j-$(VersionText-w16d-14-2j)
       Key: Usage
       Value: test-temp
 
@@ -1170,7 +1170,7 @@ jobs:
       ConnectedServiceName: $(ConnectedServiceName)
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
-      resourceGroupName: BakingDP-w16d142j$(VersionText-w16d-14-2j)
+      resourceGroupName: BakingDP-w16d-14-2j-$(VersionText-w16d-14-2j)
 
 - job: Job_8
   displayName: 'Agent job : w16d-15-0j'
@@ -1277,7 +1277,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w16d-15-0j$(VersionText-w16d-15-0j)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2016-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w16d-15-0j-$(VersionText-w16d-15-0j)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2016-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -1285,7 +1285,7 @@ jobs:
     continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w16d150j$(VersionText-w16d-15-0j)
+      ResourceGroupName: BakingDP-w16d-15-0j-$(VersionText-w16d-15-0j)
       Key: Usage
       Value: test-temp
 
@@ -1339,7 +1339,7 @@ jobs:
       ConnectedServiceName: $(ConnectedServiceName)
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
-      resourceGroupName: BakingDP-w16d150j$(VersionText-w16d-15-0j)
+      resourceGroupName: BakingDP-w16d-15-0j-$(VersionText-w16d-15-0j)
 - job: Job_9
   displayName: 'Agent job : w19d-15-0j'
   timeoutInMinutes: 360
@@ -1445,7 +1445,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d-15-0j$(VersionText-w19d-15-0j)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w19d-15-0j-$(VersionText-w19d-15-0j)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -1453,7 +1453,7 @@ jobs:
     continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w19d150j$(VersionText-w19d-15-0j)
+      ResourceGroupName: BakingDP-w19d-15-0j-$(VersionText-w19d-15-0j)
       Key: Usage
       Value: test-temp
 
@@ -1507,7 +1507,7 @@ jobs:
       ConnectedServiceName: $(ConnectedServiceName)
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
-      resourceGroupName: BakingDP-w19d150j$(VersionText-w19d-15-0j)
+      resourceGroupName: BakingDP-w19d-15-0j-$(VersionText-w19d-15-0j)
 
 - job: Job_10
   displayName: 'Agent job : w19d-14-2j'
@@ -1614,7 +1614,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d-14-2j$(VersionText-w19d-14-2j)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName  $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w19d-14-2j-$(VersionText-w19d-14-2j)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName  $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -1622,7 +1622,7 @@ jobs:
     continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w19d142j$(VersionText-w19d-14-2j)
+      ResourceGroupName: BakingDP-w19d-14-2j-$(VersionText-w19d-14-2j)
       Key: Usage
       Value: test-temp
 
@@ -1676,7 +1676,7 @@ jobs:
       ConnectedServiceName: $(ConnectedServiceName)
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
-      resourceGroupName: BakingDP-w19d142j$(VersionText-w19d-14-2j)
+      resourceGroupName: BakingDP-w19d-14-2j-$(VersionText-w19d-14-2j)
 
 - job: Job_11
   displayName: 'Agent job : w22d-15-0j'
@@ -1783,7 +1783,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w22d-15-0j$(VersionText-w22d-15-0j)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2022-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w22d-15-0j-$(VersionText-w22d-15-0j)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2022-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -1791,7 +1791,7 @@ jobs:
     continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w22d150j$(VersionText-w22d-15-0j)
+      ResourceGroupName: BakingDP-w22d-15-0j-$(VersionText-w22d-15-0j)
       Key: Usage
       Value: test-temp
 
@@ -1845,7 +1845,7 @@ jobs:
       ConnectedServiceName: $(ConnectedServiceName)
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
-      resourceGroupName: BakingDP-w19d150j$(VersionText-w19d-15-0j)
+      resourceGroupName: BakingDP-w22d-15-0j-$(VersionText-w22d-15-0j)
 
 - job: Job_12
   displayName: 'Agent job : w22d-14-2j'
@@ -1952,7 +1952,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w22d-14-2j$(VersionText-w22d-14-2j)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName  $(Windows-2022-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w22d-14-2j-$(VersionText-w22d-14-2j)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName  $(Windows-2022-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -1960,7 +1960,7 @@ jobs:
     continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w22d142j$(VersionText-w22d-14-2j)
+      ResourceGroupName: BakingDP-w22d-14-2j-$(VersionText-w22d-14-2j)
       Key: Usage
       Value: test-temp
 
@@ -2014,5 +2014,5 @@ jobs:
       ConnectedServiceName: $(ConnectedServiceName)
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
-      resourceGroupName: BakingDP-w22d142j$(VersionText-w22d-14-2j)
+      resourceGroupName: BakingDP-w22d-14-2j-$(VersionText-w22d-14-2j)
 ...

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -192,7 +192,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText '$(VersionText-w19d-14-2)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText $(VersionText-w19d-14-2) -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses $(ExternalIPAddresses)
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -192,13 +192,13 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d142$(VersionText-w19d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses $(ExternalIPAddresses)
+      arguments: -VersionText 'w19d142$(VersionText-w19d-14-2)$(Build.BuildId)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses $(ExternalIPAddresses)
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w22d142$(VersionText-w22d-14-2)$(Build.BuildId)
+      ResourceGroupName: BakingDP-w22d142$(VersionText-w22d-14-2)$(Build.BuildNumber)
       Key: Usage
       Value: test-temp
   - task: PowerShell@2

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -119,10 +119,10 @@ jobs:
     name: ''
     displayName: VM Tests
     env:
-    TestImageName: w22d142$(VersionText-w22d-14-2)$(Build.BuildNumber)
-    TestCloudName: Azure
-    AtomicBuild: $(atomic-build)
-    TestVmName: Test22142$(VersionText-w22d-14-2)$(Build.BuildNumber)
+        TestImageName: w22d142$(VersionText-w22d-14-2)$(Build.BuildNumber)
+        TestCloudName: Azure
+        AtomicBuild: $(atomic-build)
+        TestVmName: Test22142$(VersionText-w22d-14-2)$(Build.BuildNumber)
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
       script: >-
@@ -294,10 +294,10 @@ jobs:
   - task: PowerShell@2
     displayName: VM Tests
     env:
-    TestImageName: w22d150$(VersionText-w22d-15-0)$(Build.BuildNumber)
-    TestCloudName: Azure
-    AtomicBuild: $(atomic-build)
-    TestVmName: Test22150$(VersionText-w22d-15-0)$(Build.BuildNumber)
+        TestImageName: w22d150$(VersionText-w22d-15-0)$(Build.BuildNumber)
+        TestCloudName: Azure
+        AtomicBuild: $(atomic-build)
+        TestVmName: Test22150$(VersionText-w22d-15-0)$(Build.BuildNumber)
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
       script: >-

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -1,14 +1,8 @@
-name: Azure-Images-Cookbooks-CI-3.0-$(Build.BuildId)
+name: Azure Images Cookbooks CI-$(Build.BuildId)
 
 trigger: none
 
 pr: none
-
-resources:
-  repositories:
-  - repository: self
-    type: git
-    ref: feature/priyanka-classic2YAML
 
 variables: 
   - group: 'External IP Addresses'
@@ -20,14 +14,6 @@ variables:
     value: $false
   - name: azureUserId
     value: PowershellScriptsSP
-  # - name: clientsecret
-    # value: ********
-  - name: GitBranch
-    value: $(Build.SourceBranch)
-  - name: GitBranchPR
-    value: feature/priyanka-classic2YAML
-  - name: GitUserName
-    value: priyadishah
   - name: JpnLanguage
     value: ENG
   - name: quickstart-scripts

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -192,7 +192,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w22d142$(VersionText-w22d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild ${env:ATOMIC-BUILD-PS} -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w22d142$(VersionText-w22d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -22,12 +22,16 @@ variables:
     value: PowershellScriptsSP
   - name:  Build-all
     value: false
-  - name: Build-w12r2d-14-2
+  - name: Build-w22d-14-2
+    value: false
+  - name: Build-w22d-15-0
+    value: false
+  - name: Build-w22d-14-2j
     value: true
-  - name: Build-w12r2d-15-0
-    value: false
+  - name: Build-w22d-15-0j
+    value: false  
   - name: Build-w16d-14-2
-    value: false
+    value: true
   - name: Build-w16d-14-2j
     value: false
   - name: Build-w16d-15-0
@@ -39,7 +43,7 @@ variables:
   - name: Build-w19d-14-2j
     value: false
   - name: Build-w19d-15-0
-    value: false
+    value: true
   - name: Build-w19d-15-0j
     value: false
   # - name: clientsecret
@@ -47,22 +51,20 @@ variables:
   - name: GitBranch
     value: $(Build.SourceBranch)
   - name: GitBranchPR
-    value: debug/paas
+    value: feature/priyanka-classic2YAML
   - name: GitUserName
-    value: robe070
+    value: priyadishah
   - name: JpnLanguage
     value: ENG
   - name: quickstart-scripts
     value: $(Agent.BuildDirectory)\test
-  - name: VersionText-w12r2d-14-2
-    value: 0
-  - name: VersionText-w12r2d-15-0
-    value: 0
   - name: VersionText-w16d-14-2
     value: 0
   - name: VersionText-w16d-15-0
     value: 0
   - name: VersionText-w16d-15-0j
+    value: 0
+  - name: VersionText-w16d-14-2j
     value: 0
   - name: VersionText-w19d-14-2
     value: 0
@@ -72,12 +74,20 @@ variables:
     value: 0
   - name: VersionText-w19d-15-0j
     value: 0
+  - name: VersionText-w22d-14-2
+    value: 0
+  - name: VersionText-w22d-14-2j
+    value: 0
+  - name: VersionText-w22d-15-0
+    value: 0
+  - name: VersionText-w22d-15-0j
+    value: 0
 
 jobs:
 - job: Job_1
-  displayName: 'Agent job : w12r2d-14-2'
+  displayName: 'Agent job : w22d-14-2'
   timeoutInMinutes: 120
-  condition: and(succeeded(), or(eq(variables['Build-w12r2d-14-2'], 'true'), eq(variables['Build-all'], 'true')))
+  condition: and(succeeded(), or(eq(variables['Build-w22d-14-2'], 'true'), eq(variables['Build-all'], 'true')))
 
 
   pool:
@@ -160,9 +170,9 @@ jobs:
 
         # Pester for Testing
 
-        Write-Host "Installing Module Pester RequiredVersion 5.0.3" | Out-Default | Write-Verbose
+        Write-Host "Installing Module Pester RequiredVersion 5.6.1" | Out-Default | Write-Verbose
 
-        Install-Module -Name Pester -RequiredVersion 5.0.3 -AllowClobber -Force
+        Install-Module -Name Pester -RequiredVersion 5.6.1 -AllowClobber -Force
 
         Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
 
@@ -182,13 +192,13 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w12r2d142$(VersionText-w12r2d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2012-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w22d142$(VersionText-w22d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2022-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w12r2d142$(VersionText-w12r2d-14-2)$(Build.BuildNumber)
+      ResourceGroupName: BakingDP-w22d142$(VersionText-w22d-14-2)$(Build.BuildNumber)
       Key: Usage
       Value: test-temp
   - task: PowerShell@2
@@ -199,7 +209,7 @@ jobs:
       script: >-
         Write-Host "Writing the Full Image URL $(BuildImage.ImageUrl) in the $(Build.ArtifactStagingDirectory)" | Out-Default | Write-Host
 
-        Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w12r2d-14-2.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
+        Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w22d-14-2.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
 
         Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
   - task: PowerShell@2
@@ -226,13 +236,13 @@ jobs:
     inputs:
       testRunner: NUnit
       testResultsFiles: '**/Test-*.xml'
-      testRunTitle: w12r2d-14-2
+      testRunTitle: w22d-14-2
   - task: PublishBuildArtifacts@1
     name: ''
     displayName: 'Publish Artifact: Image URL'
     inputs:
-      PathtoPublish: $(Build.ArtifactStagingDirectory)/w12r2d-14-2.txt
-      ArtifactName: w12r2d-14-2
+      PathtoPublish: $(Build.ArtifactStagingDirectory)/w22d-14-2.txt
+      ArtifactName: w22d-14-2
       FileCopyOptions: ''
   - task: AzureResourceManagerTemplateDeployment@3
     displayName: Delete Resource Group
@@ -240,11 +250,11 @@ jobs:
       ConnectedServiceName: $(ConnectedServiceName)
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
-      resourceGroupName: BakingDP-w12r2d142$(VersionText-w12r2d-14-2)$(Build.BuildNumber)
+      resourceGroupName: BakingDP-w22d142$(VersionText-w22d-14-2)$(Build.BuildNumber)
 - job: Job_5
-  displayName: 'Agent job : w12r2d-15-0'
+  displayName: 'Agent job : w22d-15-0'
   timeoutInMinutes: 360
-  condition: and(succeeded(), or(eq(variables['Build-w12r2d-15-0'], 'true'), eq(variables['Build-all'], 'true')))
+  condition: and(succeeded(), or(eq(variables['Build-w22d-15-0'], 'true'), eq(variables['Build-all'], 'true')))
   pool:
     vmImage: windows-2019
   steps:
@@ -323,9 +333,9 @@ jobs:
 
         # Pester for Testing
 
-        Write-Host "Installing Module Pester RequiredVersion 5.0.3" | Out-Default | Write-Verbose
+        Write-Host "Installing Module Pester RequiredVersion 5.6.1" | Out-Default | Write-Verbose
 
-        Install-Module -Name Pester -RequiredVersion 5.0.3 -AllowClobber -Force
+        Install-Module -Name Pester -RequiredVersion 5.6.1 -AllowClobber -Force
 
         Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
 
@@ -344,14 +354,14 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w12r2d150$(VersionText-w12r2d-15-0)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2012-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w22d150$(VersionText-w22d-15-0)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2012-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
     continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w12r2d150$(VersionText-w12r2d-15-0)$(Build.BuildNumber)
+      ResourceGroupName: BakingDP-w22d150$(VersionText-w22d-15-0)$(Build.BuildNumber)
       Key: Usage
       Value: test-temp
   - task: PowerShell@2
@@ -361,7 +371,7 @@ jobs:
       script: >-
         Write-Host "Writing the Full Image URL $(BuildImage.ImageUrl) in the $(Build.ArtifactStagingDirectory)" | Out-Default | Write-Host
 
-        Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w12r2d-15-0.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
+        Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w22d-15-0.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
 
         Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
   - task: PowerShell@2
@@ -387,12 +397,12 @@ jobs:
     inputs:
       testRunner: NUnit
       testResultsFiles: '**/Test-*.xml'
-      testRunTitle: w12r2d-15-0
+      testRunTitle: w22d-15-0
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: Image URL'
     inputs:
-      PathtoPublish: $(Build.ArtifactStagingDirectory)/w12r2d-15-0.txt
-      ArtifactName: w12r2d-15-0
+      PathtoPublish: $(Build.ArtifactStagingDirectory)/w22d-15-0.txt
+      ArtifactName: w22d-15-0
       FileCopyOptions: ''
   - task: AzureResourceManagerTemplateDeployment@3
     displayName: Delete Resource Group
@@ -400,7 +410,7 @@ jobs:
       ConnectedServiceName: $(ConnectedServiceName)
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
-      resourceGroupName: BakingDP-w12r2d150$(VersionText-w12r2d-15-0)$(Build.BuildNumber)
+      resourceGroupName: BakingDP-w22d150$(VersionText-w22d-15-0)$(Build.BuildNumber)
 - job: Job_6
   displayName: 'Agent job : w16d-14-2'
   timeoutInMinutes: 360
@@ -483,9 +493,9 @@ jobs:
 
         # Pester for Testing
 
-        Write-Host "Installing Module Pester RequiredVersion 5.0.3" | Out-Default | Write-Verbose
+        Write-Host "Installing Module Pester RequiredVersion 5.6.1" | Out-Default | Write-Verbose
 
-        Install-Module -Name Pester -RequiredVersion 5.0.3 -AllowClobber -Force
+        Install-Module -Name Pester -RequiredVersion 5.6.1 -AllowClobber -Force
 
         Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
 
@@ -643,9 +653,9 @@ jobs:
 
         # Pester for Testing
 
-        Write-Host "Installing Module Pester RequiredVersion 5.0.3" | Out-Default | Write-Verbose
+        Write-Host "Installing Module Pester RequiredVersion 5.6.1" | Out-Default | Write-Verbose
 
-        Install-Module -Name Pester -RequiredVersion 5.0.3 -AllowClobber -Force
+        Install-Module -Name Pester -RequiredVersion 5.6.1 -AllowClobber -Force
 
         Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
 
@@ -803,9 +813,9 @@ jobs:
 
         # Pester for Testing
 
-        Write-Host "Installing Module Pester RequiredVersion 5.0.3" | Out-Default | Write-Verbose
+        Write-Host "Installing Module Pester RequiredVersion 5.6.1" | Out-Default | Write-Verbose
 
-        Install-Module -Name Pester -RequiredVersion 5.0.3 -AllowClobber -Force
+        Install-Module -Name Pester -RequiredVersion 5.6.1 -AllowClobber -Force
 
         Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
 
@@ -963,9 +973,9 @@ jobs:
 
         # Pester for Testing
 
-        Write-Host "Installing Module Pester RequiredVersion 5.0.3" | Out-Default | Write-Verbose
+        Write-Host "Installing Module Pester RequiredVersion 5.6.1" | Out-Default | Write-Verbose
 
-        Install-Module -Name Pester -RequiredVersion 5.0.3 -AllowClobber -Force
+        Install-Module -Name Pester -RequiredVersion 5.6.1 -AllowClobber -Force
 
         Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
 
@@ -1123,9 +1133,9 @@ jobs:
 
         # Pester for Testing
 
-        Write-Host "Installing Module Pester RequiredVersion 5.0.3" | Out-Default | Write-Verbose
+        Write-Host "Installing Module Pester RequiredVersion 5.6.1" | Out-Default | Write-Verbose
 
-        Install-Module -Name Pester -RequiredVersion 5.0.3 -AllowClobber -Force
+        Install-Module -Name Pester -RequiredVersion 5.6.1 -AllowClobber -Force
 
         Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
 
@@ -1283,9 +1293,9 @@ jobs:
 
         # Pester for Testing
 
-        Write-Host "Installing Module Pester RequiredVersion 5.0.3" | Out-Default | Write-Verbose
+        Write-Host "Installing Module Pester RequiredVersion 5.6.1" | Out-Default | Write-Verbose
 
-        Install-Module -Name Pester -RequiredVersion 5.0.3 -AllowClobber -Force
+        Install-Module -Name Pester -RequiredVersion 5.6.1 -AllowClobber -Force
 
         Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
 
@@ -1443,9 +1453,9 @@ jobs:
 
         # Pester for Testing
 
-        Write-Host "Installing Module Pester RequiredVersion 5.0.3" | Out-Default | Write-Verbose
+        Write-Host "Installing Module Pester RequiredVersion 5.6.1" | Out-Default | Write-Verbose
 
-        Install-Module -Name Pester -RequiredVersion 5.0.3 -AllowClobber -Force
+        Install-Module -Name Pester -RequiredVersion 5.6.1 -AllowClobber -Force
 
         Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
 
@@ -1603,9 +1613,9 @@ jobs:
 
         # Pester for Testing
 
-        Write-Host "Installing Module Pester RequiredVersion 5.0.3" | Out-Default | Write-Verbose
+        Write-Host "Installing Module Pester RequiredVersion 5.6.1" | Out-Default | Write-Verbose
 
-        Install-Module -Name Pester -RequiredVersion 5.0.3 -AllowClobber -Force
+        Install-Module -Name Pester -RequiredVersion 5.6.1 -AllowClobber -Force
 
         Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
 
@@ -1681,4 +1691,324 @@ jobs:
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
       resourceGroupName: BakingDP-w19d142j$(VersionText-w19d-14-2j)$(Build.BuildNumber)
+- job: Job_11
+  displayName: 'Agent job : w22d-15-0j'
+  timeoutInMinutes: 360
+  condition: and(succeeded(), or(eq(variables['Build-w22d-15-0j'], 'true'), eq(variables['Build-all'], 'true')))
+  pool:
+    vmImage: windows-2019
+  steps:
+  - checkout: self
+    fetchTags: false
+  - task: PowerShell@2
+    displayName: Install PS Module
+    inputs:
+      filePath: scripts/install-powershell-modules-azure.ps1
+      script: >-
+        if ("$(GitBranch)".Contains("refs/heads")) {
+            $branch ="$(GitBranch)".replace("refs/heads/", "")
+        } else {
+            $branch = "$(GitBranchPR)"
+        }
+
+        $branch | Write-Host | Out-Default | Write-Verbose
+
+        Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
+
+        if ($Env:PsModuleInstalled -eq 'true') {
+            Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
+            return;
+        }
+
+
+        Write-Host "Installing Module AzureRM" | Out-Default | Write-Verbose
+
+        Install-Module -Name AzureRM -AllowClobber -Force
+
+        Write-Host "Installed Module AzureRM" | Out-Default | Write-Verbose
+
+
+        Write-Host "Installing Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.KeyVault -RequiredVersion 2.0.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
+
+
+        # Az.Accounts for Get-AzVMImage
+
+        Write-Host "Installing Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Accounts -RequiredVersion 1.9.2 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
+
+
+        # Az.Compute for Connect-AzAccount
+
+        Write-Host "Installing Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Compute -RequiredVersion 4.2.1 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
+
+
+        # Az.Resources for Get-AzResource
+
+        Write-Host "Installing Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Resources -RequiredVersion 2.4.0 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
+
+
+        # Az for Azure Modules
+
+        Write-Host "Installing Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az -RequiredVersion 4.5.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
+
+
+        # Pester for Testing
+
+        Write-Host "Installing Module Pester RequiredVersion 5.6.1" | Out-Default | Write-Verbose
+
+        Install-Module -Name Pester -RequiredVersion 5.6.1 -AllowClobber -Force
+
+        Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
+
+
+        $Env:PsModuleInstalled = 'true'
+      errorActionPreference: continue
+  - task: PowerShell@2
+    displayName: Azure Login
+    inputs:
+      filePath: scripts/AzureLogin.ps1
+      arguments: -CloudAccount $(azureUserId) -CloudSecret (ConvertTo-SecureString "$(clientSecret)" -AsPlainText -force)
+      workingDirectory: scripts
+  - task: PowerShell@2
+    name: BuildImage
+    displayName: Build Image
+    timeoutInMinutes: 120
+    inputs:
+      filePath: scripts/bake-scalable-azure-image-pipeline.ps1
+      arguments: -VersionText 'w22d150j$(VersionText-w22d-15-0j)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2022-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      workingDirectory: scripts
+  - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
+    displayName: Azure Resource Group Tagging
+    continueOnError: true
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      ResourceGroupName: BakingDP-w22d150j$(VersionText-w22d-15-0j)$(Build.BuildNumber)
+      Key: Usage
+      Value: test-temp
+  - task: PowerShell@2
+    displayName: 'Generate: Image URL'
+    inputs:
+      targetType: inline
+      script: >-
+        Write-Host "Writing the Full Image URL $(BuildImage.ImageUrl) in the $(Build.ArtifactStagingDirectory)" | Out-Default | Write-Host
+
+        Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w22d-15-0j.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
+
+        Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
+  - task: PowerShell@2
+    displayName: VM Tests
+    inputs:
+      filePath: scripts/invoke-pester-tests.ps1
+      script: >-
+        # Invoke Pester Tests
+
+        cd $(System.DefaultWorkingDirectory)\Tests
+
+        $result = Invoke-Pester -Script '.\Image*' -OutputFormat  NUnitXml -OutputFile '$(System.DefaultWorkingDirectory)\Test-Vm.xml' -PassThru
+
+        $result | Out-Default | Write-Host
+
+        if ($result.Result -eq "Failed") {
+            throw "Failed Tests Count: $($result.FailedCount)"
+        } else {
+            Write-Host "Tested the image successfully."
+        }
+  - task: PublishTestResults@2
+    displayName: Publish Test Results **/Test-*.xml
+    inputs:
+      testRunner: NUnit
+      testResultsFiles: '**/Test-*.xml'
+      testRunTitle: w22d-15-0j
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: Image URL'
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)/w22d-15-0j.txt
+      ArtifactName: w22d-15-0j
+      FileCopyOptions: ''
+  - task: AzureResourceManagerTemplateDeployment@3
+    displayName: Delete Resource Group
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
+      action: DeleteRG
+      resourceGroupName: BakingDP-w19d150j$(VersionText-w19d-15-0j)$(Build.BuildNumber)
+- job: Job_12
+  displayName: 'Agent job : w22d-14-2j'
+  timeoutInMinutes: 360
+  condition: and(succeeded(), or(eq(variables['Build-w22d-14-2j'], 'true'), eq(variables['Build-all'], 'true')))
+  pool:
+    vmImage: windows-2019
+  steps:
+  - checkout: self
+    fetchTags: false
+  - task: PowerShell@2
+    displayName: Install PS Module
+    inputs:
+      filePath: scripts/install-powershell-modules-azure.ps1
+      script: >-
+        if ("$(GitBranch)".Contains("refs/heads")) {
+            $branch ="$(GitBranch)".replace("refs/heads/", "")
+        } else {
+            $branch = "$(GitBranchPR)"
+        }
+
+        $branch | Write-Host | Out-Default | Write-Verbose
+
+        Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
+
+        if ($Env:PsModuleInstalled -eq 'true') {
+            Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
+            return;
+        }
+
+
+        Write-Host "Installing Module AzureRM" | Out-Default | Write-Verbose
+
+        Install-Module -Name AzureRM -AllowClobber -Force
+
+        Write-Host "Installed Module AzureRM" | Out-Default | Write-Verbose
+
+
+        Write-Host "Installing Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.KeyVault -RequiredVersion 2.0.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
+
+
+        # Az.Accounts for Get-AzVMImage
+
+        Write-Host "Installing Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Accounts -RequiredVersion 1.9.2 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
+
+
+        # Az.Compute for Connect-AzAccount
+
+        Write-Host "Installing Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Compute -RequiredVersion 4.2.1 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
+
+
+        # Az.Resources for Get-AzResource
+
+        Write-Host "Installing Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Resources -RequiredVersion 2.4.0 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
+
+
+        # Az for Azure Modules
+
+        Write-Host "Installing Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az -RequiredVersion 4.5.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
+
+
+        # Pester for Testing
+
+        Write-Host "Installing Module Pester RequiredVersion 5.6.1" | Out-Default | Write-Verbose
+
+        Install-Module -Name Pester -RequiredVersion 5.6.1 -AllowClobber -Force
+
+        Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
+
+
+        $Env:PsModuleInstalled = 'true'
+      errorActionPreference: continue
+  - task: PowerShell@2
+    displayName: Azure Login
+    inputs:
+      filePath: scripts/AzureLogin.ps1
+      arguments: -CloudAccount $(azureUserId) -CloudSecret (ConvertTo-SecureString "$(clientSecret)" -AsPlainText -force)
+      workingDirectory: scripts
+  - task: PowerShell@2
+    name: BuildImage
+    displayName: Build Image
+    timeoutInMinutes: 120
+    inputs:
+      filePath: scripts/bake-scalable-azure-image-pipeline.ps1
+      arguments: -VersionText 'w22d142j$(VersionText-w22d-14-2j)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName  $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      workingDirectory: scripts
+  - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
+    displayName: Azure Resource Group Tagging
+    continueOnError: true
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      ResourceGroupName: BakingDP-w22d142j$(VersionText-w22d-14-2j)$(Build.BuildNumber)
+      Key: Usage
+      Value: test-temp
+  - task: PowerShell@2
+    displayName: 'Generate: Image URL'
+    inputs:
+      targetType: inline
+      script: >-
+        Write-Host "Writing the Full Image URL $(BuildImage.ImageUrl) in the $(Build.ArtifactStagingDirectory)" | Out-Default | Write-Host
+
+        Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w22d-14-2j.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
+
+        Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
+  - task: PowerShell@2
+    displayName: VM Tests
+    inputs:
+      filePath: scripts/invoke-pester-tests.ps1
+      script: >-
+        # Invoke Pester Tests
+
+        cd $(System.DefaultWorkingDirectory)\Tests
+
+        $result = Invoke-Pester -Script '.\Image*' -OutputFormat  NUnitXml -OutputFile '$(System.DefaultWorkingDirectory)\Test-Vm.xml' -PassThru
+
+        $result | Out-Default | Write-Host
+
+        if ($result.Result -eq "Failed") {
+            throw "Failed Tests Count: $($result.FailedCount)"
+        } else {
+            Write-Host "Tested the image successfully."
+        }
+  - task: PublishTestResults@2
+    displayName: Publish Test Results **/Test-*.xml
+    inputs:
+      testRunner: NUnit
+      testResultsFiles: '**/Test-*.xml'
+      testRunTitle: w22d-14-2j
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: Image URL'
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)/w22d-14-2j.txt
+      ArtifactName: w22d-14-2j
+      FileCopyOptions: ''
+  - task: AzureResourceManagerTemplateDeployment@3
+    displayName: Delete Resource Group
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
+      action: DeleteRG
+      resourceGroupName: BakingDP-w22d142j$(VersionText-w22d-14-2j)$(Build.BuildNumber)
 ...

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -12,8 +12,6 @@ variables:
     value: $false
   - name: atomic-build-ps
     value: $false
-  - name: azureUserId
-    value: PowershellScriptsSP
   - name: JpnLanguage
     value: ENG
   - name: quickstart-scripts

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -192,13 +192,13 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText $(VersionText-w19d-14-2) -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses $(ExternalIPAddresses)
+      arguments: -VersionText 'w19d142$(VersionText-w19d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses $(ExternalIPAddresses)
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w22d142$(VersionText-w22d-14-2)$(Build.BuildNumber)
+      ResourceGroupName: BakingDP-w22d142$(VersionText-w22d-14-2)$(Build.BuildId)
       Key: Usage
       Value: test-temp
   - task: PowerShell@2

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -92,14 +92,14 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w22d-14-2$(VersionText-w22d-14-2)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2022-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses $(ExternalIPAddresses)
+      arguments: -VersionText 'w22d-14-2-$(VersionText-w22d-14-2)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2022-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses $(ExternalIPAddresses)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w22d142$(VersionText-w19d-14-2)
+      ResourceGroupName: BakingDP-w22d-14-2-$(VersionText-w22d-14-2)
       Key: Usage
       Value: test-temp
 
@@ -156,7 +156,7 @@ jobs:
       ConnectedServiceName: $(ConnectedServiceName)
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
-      resourceGroupName: BakingDP-w22d142$(VersionText-w22d-14-2)
+      resourceGroupName: BakingDP-w22d-14-2-$(VersionText-w22d-14-2)
 
 - job: Job_5
   displayName: 'Agent job : w22d-15-0'
@@ -263,7 +263,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w22d-15-0$(VersionText-w22d-15-0)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2022-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w22d-15-0-$(VersionText-w22d-15-0)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2022-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -271,7 +271,7 @@ jobs:
     continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w22d150$(VersionText-w22d-15-0)
+      ResourceGroupName: BakingDP-w22d-15-0-$(VersionText-w22d-15-0)
       Key: Usage
       Value: test-temp
 
@@ -432,7 +432,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w16d-14-2$(VersionText-w16d-14-2)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2016-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w16d-14-2-$(VersionText-w16d-14-2)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2016-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -440,7 +440,7 @@ jobs:
     continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w16d142$(VersionText-w16d-14-2)
+      ResourceGroupName: BakingDP-w16d-14-2-$(VersionText-w16d-14-2)
       Key: Usage
       Value: test-temp
 
@@ -601,7 +601,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w16d-15-0$(VersionText-w16d-15-0)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2016-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w16d-15-0-$(VersionText-w16d-15-0)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2016-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -609,7 +609,7 @@ jobs:
     continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w16d150$(VersionText-w16d-15-0)
+      ResourceGroupName: BakingDP-w16d-15-0-$(VersionText-w16d-15-0)
       Key: Usage
       Value: test-temp
 
@@ -663,7 +663,7 @@ jobs:
       ConnectedServiceName: $(ConnectedServiceName)
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
-      resourceGroupName: BakingDP-w16d150$(VersionText-w16d-15-0)
+      resourceGroupName: BakingDP-w16d-15-0-$(VersionText-w16d-15-0)
 
 - job: Job_3
   displayName: 'Agent job : w19d-14-2'

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -15,9 +15,9 @@ variables:
   - group: 'Image Names'
   - group: 'Azure Logins'
   - name: atomic-build
-    value: $False
-  # - name: atomic-build-ps
-  #   value: $False
+    value: $false
+  - name: atomic-build-ps
+    value: $false
   - name: azureUserId
     value: PowershellScriptsSP
   # - name: clientsecret

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -119,10 +119,10 @@ jobs:
     name: ''
     displayName: VM Tests
     env:
-        TestImageName: w22d142$(VersionText-w22d-14-2)$(Build.BuildNumber)
+        TestImageName: w22d-14-2-$(VersionText-w22d-14-2)
         TestCloudName: Azure
         AtomicBuild: $(atomic-build)
-        TestVmName: Test22142$(VersionText-w22d-14-2)$(Build.BuildNumber)
+        TestVmName: Test22142$(VersionText-w22d-14-2)
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
       script: >-
@@ -294,10 +294,10 @@ jobs:
   - task: PowerShell@2
     displayName: VM Tests
     env:
-        TestImageName: w22d150$(VersionText-w22d-15-0)$(Build.BuildNumber)
+        TestImageName: w22d-15-0-$(VersionText-w22d-15-0)
         TestCloudName: Azure
         AtomicBuild: $(atomic-build)
-        TestVmName: Test22150$(VersionText-w22d-15-0)$(Build.BuildNumber)
+        TestVmName: Test22150$(VersionText-w22d-15-0)
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
       script: >-
@@ -642,10 +642,10 @@ jobs:
   - task: PowerShell@2
     displayName: VM Tests
     env:
-        TestImageName: w16d150$(VersionText-w16d-15-0)$(Build.BuildNumber)
+        TestImageName: w16d-15-0-$(VersionText-w16d-15-0)
         TestCloudName: Azure
         AtomicBuild: $(atomic-build)
-        TestVmName: Test16150$(VersionText-w16d-15-0)$(Build.BuildNumber)
+        TestVmName: Test16150$(VersionText-w16d-15-0)
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
       script: >-
@@ -816,10 +816,10 @@ jobs:
   - task: PowerShell@2
     displayName: VM Tests
     env:
-        TestImageName: w19d142$(VersionText-w19d-14-2)$(Build.BuildNumber)
+        TestImageName: w19d-14-2-$(VersionText-w19d-14-2)
         TestCloudName: Azure
         AtomicBuild: $(atomic-build)
-        TestVmName: Test19142$(VersionText-w19d-14-2)$(Build.BuildNumber)
+        TestVmName: Test19142$(VersionText-w19d-14-2)
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
       script: >-
@@ -990,10 +990,10 @@ jobs:
   - task: PowerShell@2
     displayName: VM Tests
     env:
-        TestImageName: w19d150$(VersionText-w19d-15-0)$(Build.BuildNumber)
+        TestImageName: w19d-15-0-$(VersionText-w19d-15-0)
         TestCloudName: Azure
         AtomicBuild: $(atomic-build)
-        TestVmName: Test19150$(VersionText-w19d-15-0)$(Build.BuildNumber)
+        TestVmName: Test19150$(VersionText-w19d-15-0)
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
       script: >-
@@ -1164,10 +1164,10 @@ jobs:
   - task: PowerShell@2
     displayName: VM Tests
     env:
-        TestImageName: w16d142j$(VersionText-w16d-14-2j)$(Build.BuildNumber)
+        TestImageName: w16d-14-2j-$(VersionText-w16d-14-2j)
         TestCloudName: Azure
         AtomicBuild: $(atomic-build)
-        TestVmName: Test16142j$(VersionText-w16d-14-2j)$(Build.BuildNumber)
+        TestVmName: Test16142j$(VersionText-w16d-14-2j)
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
       script: >-
@@ -1338,10 +1338,10 @@ jobs:
   - task: PowerShell@2
     displayName: VM Tests
     env:
-        TestImageName: w16d150j$(VersionText-w16d-15-0j)$(Build.BuildNumber)
+        TestImageName: w16d-15-0j-$(VersionText-w16d-15-0j)
         TestCloudName: Azure
         AtomicBuild: $(atomic-build)
-        TestVmName: Test16150j$(VersionText-w16d-15-0j)$(Build.BuildNumber)
+        TestVmName: Test16150j$(VersionText-w16d-15-0j)
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
       script: >-
@@ -1511,10 +1511,10 @@ jobs:
   - task: PowerShell@2
     displayName: VM Tests
     env:
-        TestImageName: w19d150j$(VersionText-w19d-15-0j)$(Build.BuildNumber)
+        TestImageName: w19d-15-0j-$(VersionText-w19d-15-0j)
         TestCloudName: Azure
         AtomicBuild: $(atomic-build)
-        TestVmName: Test19150j$(VersionText-w19d-15-0j)$(Build.BuildNumber)
+        TestVmName: Test19150j$(VersionText-w19d-15-0j)
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
       script: >-
@@ -1685,10 +1685,10 @@ jobs:
   - task: PowerShell@2
     displayName: VM Tests
     env:
-        TestImageName: w19d142j$(VersionText-w19d-14-2j)$(Build.BuildNumber)
+        TestImageName: w19d-14-2j-$(VersionText-w19d-14-2j)
         TestCloudName: Azure
         AtomicBuild: $(atomic-build)
-        TestVmName: Test19142j$(VersionText-w19d-14-2j)$(Build.BuildNumber)
+        TestVmName: Test19142j$(VersionText-w19d-14-2j)
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
       script: >-
@@ -1859,10 +1859,10 @@ jobs:
   - task: PowerShell@2
     displayName: VM Tests
     env:
-        TestImageName: w22d150j$(VersionText-w22d-15-0j)$(Build.BuildNumber)
+        TestImageName: w22d-15-0j-$(VersionText-w22d-15-0j)
         TestCloudName: Azure
         AtomicBuild: $(atomic-build)
-        TestVmName: Test22150j$(VersionText-w22d-15-0j)$(Build.BuildNumber)
+        TestVmName: Test22150j$(VersionText-w22d-15-0j)
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
       script: >-
@@ -2033,10 +2033,10 @@ jobs:
   - task: PowerShell@2
     displayName: VM Tests
     env:
-        TestImageName: w22d142j$(VersionText-w22d-14-2j)$(Build.BuildNumber)
+        TestImageName: w22d-14-2j-$(VersionText-w22d-14-2j)
         TestCloudName: Azure
         AtomicBuild: $(atomic-build)
-        TestVmName: Test22142j$(VersionText-w22d-14-2j)$(Build.BuildNumber)
+        TestVmName: Test22142j$(VersionText-w22d-14-2j)
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
       script: >-

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -192,7 +192,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w22d142$(VersionText-w22d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w22d142$(VersionText-w22d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -1,6 +1,6 @@
 name: Azure-Images-Cookbooks-CI-3.0-$(Build.BuildId)
 
-triggers: none
+trigger: none
 
 pr: none
 
@@ -46,7 +46,7 @@ jobs:
     value: True
   - name: Build-w19d-15-0j
     value: False
-  - # name: clientsecret
+  # - name: clientsecret
     # value: ********
   - name: GitBranch
     value: $(Build.SourceBranch)

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -20,32 +20,6 @@ variables:
   #   value: $False
   - name: azureUserId
     value: PowershellScriptsSP
-  - name:  Build-all
-    value: false
-  - name: Build-w22d-14-2
-    value: true
-  - name: Build-w22d-15-0
-    value: false
-  - name: Build-w22d-14-2j
-    value: false
-  - name: Build-w22d-15-0j
-    value: false  
-  - name: Build-w16d-14-2
-    value: false
-  - name: Build-w16d-14-2j
-    value: false
-  - name: Build-w16d-15-0
-    value: false
-  - name: Build-w16d-15-0j
-    value: false
-  - name: Build-w19d-14-2
-    value: false
-  - name: Build-w19d-14-2j
-    value: false
-  - name: Build-w19d-15-0
-    value: false
-  - name: Build-w19d-15-0j
-    value: false
   # - name: clientsecret
     # value: ********
   - name: GitBranch

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -72,8 +72,6 @@ variables:
     value: 0
   - name: VersionText-w19d-15-0j
     value: 0
-  - name: ConnectedServiceName
-    value: $(ConnectedServiceName)
 
 jobs:
 - job: Job_1

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -182,7 +182,7 @@ jobs:
       ConnectedServiceName: $(ConnectedServiceName)
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
-      resourceGroupName: BakingDP-w22d142$(VersionText-w22d-14-2)$(Build.BuildNumber)
+      resourceGroupName: BakingDP-w19d142$(VersionText-w19d-14-2)$(Build.BuildId)
 
 - job: Job_5
   displayName: 'Agent job : w22d-15-0'

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -468,10 +468,10 @@ jobs:
   - task: PowerShell@2
     displayName: VM Tests
     env:
-        TestImageName: w16d142$(VersionText-w16d-14-2)$(Build.BuildNumber)
+        TestImageName: w16d-14-2-$(VersionText-w16d-14-2)
         TestCloudName: Azure
         AtomicBuild: $(atomic-build)
-        TestVmName: Test16142$(VersionText-w16d-14-2)$(Build.BuildNumber)
+        TestVmName: Test16142$(VersionText-w16d-14-2)
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
       script: >-

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -92,7 +92,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d142$(VersionText-w19d-14-2)$(Build.BuildId)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses $(ExternalIPAddresses)
+      arguments: -VersionText 'w19d142$(VersionText-w19d-14-2)$(Build.BuildId)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -GitUserName $(GitUserName) -ExternalIPAddresses $(ExternalIPAddresses)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -263,7 +263,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w22d150$(VersionText-w22d-15-0)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2012-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w22d150$(VersionText-w22d-15-0)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2012-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -432,7 +432,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w16d142$(VersionText-w16d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2016-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w16d142$(VersionText-w16d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2016-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -601,7 +601,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w16d150$(VersionText-w16d-15-0)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2016-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps']) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w16d150$(VersionText-w16d-15-0)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2016-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -770,7 +770,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d142$(VersionText-w19d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w19d142$(VersionText-w19d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -939,7 +939,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d150$(VersionText-w19d-15-0)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w19d150$(VersionText-w19d-15-0)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -1108,7 +1108,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w16d142j$(VersionText-w16d-14-2j)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2016-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w16d142j$(VersionText-w16d-14-2j)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2016-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -1277,7 +1277,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w16d150j$(VersionText-w16d-15-0j)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2016-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w16d150j$(VersionText-w16d-15-0j)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2016-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -1446,7 +1446,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d150j$(VersionText-w19d-15-0j)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w19d150j$(VersionText-w19d-15-0j)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -1615,7 +1615,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d142j$(VersionText-w19d-14-2j)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName  $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w19d142j$(VersionText-w19d-14-2j)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName  $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -1784,7 +1784,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w22d150j$(VersionText-w22d-15-0j)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2022-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w22d150j$(VersionText-w22d-15-0j)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2022-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -1953,7 +1953,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w22d142j$(VersionText-w22d-14-2j)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName  $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w22d142j$(VersionText-w22d-14-2j)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName  $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -192,7 +192,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w22d142$(VersionText-w22d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w19d142$(VersionText-w19d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -1,0 +1,1691 @@
+name: Azure-Images-Cookbooks-CI-3.0-$(Build.BuildId)
+
+triggers: none
+
+pr: none
+
+resources:
+  repositories:
+  - repository: self
+    type: git
+    ref: refs/heads/debug/paas
+
+jobs:
+- job: Job_1
+  displayName: 'Agent job : w12r2d-14-2'
+  timeoutInMinutes: 120
+  condition: and(succeeded(), or(eq(variables['Build-w12r2d-14-2'], 'True'), eq(variables['Build-all'], 'True')))
+  variables: 
+  - group: 'External IP Addresses'
+  - group: 'Image Names'
+  - name: atomic-build
+    value: false
+  - name: atomic-build-ps
+    value: false
+  - name: azureUserId
+    value: LPC-AsBake
+  - name:  Build-all
+    value: False
+  - name: Build-w12r2d-14-2
+    value: False
+  - name: Build-w12r2d-15-0
+    value: False
+  - name: Build-w16d-14-2
+    value: False
+  - name: Build-w16d-14-2j
+    value: False
+  - name: Build-w16d-15-0
+    value: False
+  - name: Build-w16d-15-0j
+    value: False
+  - name: Build-w19d-14-2
+    value: False
+  - name: Build-w19d-14-2j
+    value: False
+  - name: Build-w19d-15-0
+    value: True
+  - name: Build-w19d-15-0j
+    value: False
+  - # name: clientsecret
+    # value: ********
+  - name: GitBranch
+    value: $(Build.SourceBranch)
+  - name: GitBranchPR
+    value: debug/paas
+  - name: GitUserName
+    value: robe070
+  - name: JpnLanguage
+    value: ENG
+  - name: quickstart-scripts
+    value: $(Agent.BuildDirectory)\test
+  - name: system.collectionId
+    value: 556ac44f-caae-4fef-a5b6-d964fed453e6
+  - name: system.debug
+    value: false
+  - name: system.definitionId
+    value: 30
+  - name: system.teamProject
+    value: 'Lansa Azure Scalable License Images'
+  - name: VersionText-w12r2d-14-2
+    value: 0
+  - name: VersionText-w12r2d-15-0
+    value: 0
+  - name: VersionText-w16d-14-2
+    value: 0
+  - name: VersionText-w16d-15-0
+    value: 0
+  - name: VersionText-w16d-15-0j
+    value: 0
+  - name: VersionText-w19d-14-2
+    value: 0
+  - name: VersionText-w19d-14-2j
+    value: 0
+  - name: VersionText-w19d-15-0
+    value: 0
+  - name: VersionText-w19d-15-0j
+    value: 0
+  - name: ConnectedServiceName
+    value: $(ConnectedServiceName)
+
+  pool:
+    vmImage: windows-2019
+    
+  steps:
+  - checkout: self
+    fetchTags: false
+  - task: PowerShell@2
+    name: ''
+    displayName: Install PS Module
+    inputs:
+      filePath: scripts/install-powershell-modules-azure.ps1
+      script: >-
+        if ("$(GitBranch)".Contains("refs/heads")) {
+            $branch ="$(GitBranch)".replace("refs/heads/", "")
+        } else {
+            $branch = "$(GitBranchPR)"
+        }
+
+        $branch | Write-Host | Out-Default | Write-Verbose
+
+        Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
+
+        if ($Env:PsModuleInstalled -eq 'True') {
+            Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
+            return;
+        }
+
+
+        Write-Host "Installing Module AzureRM" | Out-Default | Write-Verbose
+
+        Install-Module -Name AzureRM -AllowClobber -Force
+
+        Write-Host "Installed Module AzureRM" | Out-Default | Write-Verbose
+
+
+        Write-Host "Installing Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.KeyVault -RequiredVersion 2.0.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
+
+
+        # Az.Accounts for Get-AzVMImage
+
+        Write-Host "Installing Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Accounts -RequiredVersion 1.9.2 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
+
+
+        # Az.Compute for Connect-AzAccount
+
+        Write-Host "Installing Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Compute -RequiredVersion 4.2.1 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
+
+
+        # Az.Resources for Get-AzResource
+
+        Write-Host "Installing Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Resources -RequiredVersion 2.4.0 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
+
+
+        # Az for Azure Modules
+
+        Write-Host "Installing Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az -RequiredVersion 4.5.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
+
+
+        # Pester for Testing
+
+        Write-Host "Installing Module Pester RequiredVersion 5.0.3" | Out-Default | Write-Verbose
+
+        Install-Module -Name Pester -RequiredVersion 5.0.3 -AllowClobber -Force
+
+        Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
+
+
+        $Env:PsModuleInstalled = 'True'
+      errorActionPreference: continue
+  - task: PowerShell@2
+    name: ''
+    displayName: Azure Login
+    inputs:
+      filePath: scripts/AzureLogin.ps1
+      arguments: -CloudAccount $(azureUserId) -CloudSecret (ConvertTo-SecureString "$(clientSecret)" -AsPlainText -force)
+      workingDirectory: scripts
+  - task: PowerShell@2
+    name: BuildImage
+    displayName: Build Image
+    timeoutInMinutes: 120
+    inputs:
+      filePath: scripts/bake-scalable-azure-image-pipeline.ps1
+      arguments: -VersionText 'w12r2d142$(VersionText-w12r2d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2012-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      workingDirectory: scripts
+  - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
+    displayName: Azure Resource Group Tagging
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      ResourceGroupName: BakingDP-w12r2d142$(VersionText-w12r2d-14-2)$(Build.BuildNumber)
+      Key: Usage
+      Value: test-temp
+  - task: PowerShell@2
+    name: ''
+    displayName: 'Generate: Image URL'
+    inputs:
+      targetType: inline
+      script: >-
+        Write-Host "Writing the Full Image URL $(BuildImage.ImageUrl) in the $(Build.ArtifactStagingDirectory)" | Out-Default | Write-Host
+
+        Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w12r2d-14-2.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
+
+        Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
+  - task: PowerShell@2
+    name: ''
+    displayName: VM Tests
+    inputs:
+      filePath: scripts/invoke-pester-tests.ps1
+      script: >-
+        # Invoke Pester Tests
+
+        cd $(System.DefaultWorkingDirectory)\Tests
+
+        $result = Invoke-Pester -Script '.\Image*' -OutputFormat  NUnitXml -OutputFile '$(System.DefaultWorkingDirectory)\Test-Vm.xml' -PassThru
+
+        $result | Out-Default | Write-Host
+
+        if ($result.Result -eq "Failed") {
+            throw "Failed Tests Count: $($result.FailedCount)"
+        } else {
+            Write-Host "Tested the image successfully."
+        }
+  - task: PublishTestResults@2
+    displayName: Publish Test Results **/Test-*.xml
+    inputs:
+      testRunner: NUnit
+      testResultsFiles: '**/Test-*.xml'
+      testRunTitle: w12r2d-14-2
+  - task: PublishBuildArtifacts@1
+    name: ''
+    displayName: 'Publish Artifact: Image URL'
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)/w12r2d-14-2.txt
+      ArtifactName: w12r2d-14-2
+      FileCopyOptions: ''
+  - task: AzureResourceManagerTemplateDeployment@3
+    displayName: Delete Resource Group
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
+      action: DeleteRG
+      resourceGroupName: BakingDP-w12r2d142$(VersionText-w12r2d-14-2)$(Build.BuildNumber)
+- job: Job_5
+  displayName: 'Agent job : w12r2d-15-0'
+  timeoutInMinutes: 360
+  condition: and(succeeded(), or(eq(variables['Build-w12r2d-15-0'], 'True'), eq(variables['Build-all'], 'True')))
+  pool:
+    vmImage: windows-2019
+  steps:
+  - checkout: self
+    fetchTags: false
+  - task: PowerShell@2
+    displayName: Install PS Module
+    inputs:
+      filePath: scripts/install-powershell-modules-azure.ps1
+      script: >-
+        if ("$(GitBranch)".Contains("refs/heads")) {
+            $branch ="$(GitBranch)".replace("refs/heads/", "")
+        } else {
+            $branch = "$(GitBranchPR)"
+        }
+
+        $branch | Write-Host | Out-Default | Write-Verbose
+
+        Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
+
+        if ($Env:PsModuleInstalled -eq 'True') {
+            Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
+            return;
+        }
+
+
+        Write-Host "Installing Module AzureRM" | Out-Default | Write-Verbose
+
+        Install-Module -Name AzureRM -AllowClobber -Force
+
+        Write-Host "Installed Module AzureRM" | Out-Default | Write-Verbose
+
+
+        Write-Host "Installing Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.KeyVault -RequiredVersion 2.0.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
+
+
+        # Az.Accounts for Get-AzVMImage
+
+        Write-Host "Installing Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Accounts -RequiredVersion 1.9.2 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
+
+
+        # Az.Compute for Connect-AzAccount
+
+        Write-Host "Installing Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Compute -RequiredVersion 4.2.1 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
+
+
+        # Az.Resources for Get-AzResource
+
+        Write-Host "Installing Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Resources -RequiredVersion 2.4.0 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
+
+
+        # Az for Azure Modules
+
+        Write-Host "Installing Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az -RequiredVersion 4.5.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
+
+
+        # Pester for Testing
+
+        Write-Host "Installing Module Pester RequiredVersion 5.0.3" | Out-Default | Write-Verbose
+
+        Install-Module -Name Pester -RequiredVersion 5.0.3 -AllowClobber -Force
+
+        Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
+
+
+        $Env:PsModuleInstalled = 'True'
+      errorActionPreference: continue
+  - task: PowerShell@2
+    displayName: Azure Login
+    inputs:
+      filePath: scripts/AzureLogin.ps1
+      arguments: -CloudAccount $(azureUserId) -CloudSecret (ConvertTo-SecureString "$(clientSecret)" -AsPlainText -force)
+      workingDirectory: scripts
+  - task: PowerShell@2
+    name: BuildImage
+    displayName: Build Image
+    timeoutInMinutes: 120
+    inputs:
+      filePath: scripts/bake-scalable-azure-image-pipeline.ps1
+      arguments: -VersionText 'w12r2d150$(VersionText-w12r2d-15-0)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2012-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      workingDirectory: scripts
+  - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
+    displayName: Azure Resource Group Tagging
+    continueOnError: True
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      ResourceGroupName: BakingDP-w12r2d150$(VersionText-w12r2d-15-0)$(Build.BuildNumber)
+      Key: Usage
+      Value: test-temp
+  - task: PowerShell@2
+    displayName: 'Generate: Image URL'
+    inputs:
+      targetType: inline
+      script: >-
+        Write-Host "Writing the Full Image URL $(BuildImage.ImageUrl) in the $(Build.ArtifactStagingDirectory)" | Out-Default | Write-Host
+
+        Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w12r2d-15-0.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
+
+        Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
+  - task: PowerShell@2
+    displayName: VM Tests
+    inputs:
+      filePath: scripts/invoke-pester-tests.ps1
+      script: >-
+        # Invoke Pester Tests
+
+        cd $(System.DefaultWorkingDirectory)\Tests
+
+        $result = Invoke-Pester -Script '.\Image*' -OutputFormat  NUnitXml -OutputFile '$(System.DefaultWorkingDirectory)\Test-Vm.xml' -PassThru
+
+        $result | Out-Default | Write-Host
+
+        if ($result.Result -eq "Failed") {
+            throw "Failed Tests Count: $($result.FailedCount)"
+        } else {
+            Write-Host "Tested the image successfully."
+        }
+  - task: PublishTestResults@2
+    displayName: Publish Test Results **/Test-*.xml
+    inputs:
+      testRunner: NUnit
+      testResultsFiles: '**/Test-*.xml'
+      testRunTitle: w12r2d-15-0
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: Image URL'
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)/w12r2d-15-0.txt
+      ArtifactName: w12r2d-15-0
+      FileCopyOptions: ''
+  - task: AzureResourceManagerTemplateDeployment@3
+    displayName: Delete Resource Group
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
+      action: DeleteRG
+      resourceGroupName: BakingDP-w12r2d150$(VersionText-w12r2d-15-0)$(Build.BuildNumber)
+- job: Job_6
+  displayName: 'Agent job : w16d-14-2'
+  timeoutInMinutes: 360
+  condition: and(succeeded(), or(eq(variables['Build-w16d-14-2'], 'True'), eq(variables['Build-all'], 'True')))
+  pool:
+    vmImage: windows-2019
+  steps:
+  - checkout: self
+    fetchTags: false
+  - task: PowerShell@2
+    displayName: Install PS Module
+    inputs:
+      filePath: scripts/install-powershell-modules-azure.ps1
+      script: >-
+        if ("$(GitBranch)".Contains("refs/heads")) {
+            $branch ="$(GitBranch)".replace("refs/heads/", "")
+        } else {
+            $branch = "$(GitBranchPR)"
+        }
+
+        $branch | Write-Host | Out-Default | Write-Verbose
+
+        Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
+
+        if ($Env:PsModuleInstalled -eq 'True') {
+            Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
+            return;
+        }
+
+
+        Write-Host "Installing Module AzureRM" | Out-Default | Write-Verbose
+
+        Install-Module -Name AzureRM -AllowClobber -Force
+
+        Write-Host "Installed Module AzureRM" | Out-Default | Write-Verbose
+
+
+        Write-Host "Installing Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.KeyVault -RequiredVersion 2.0.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
+
+
+        # Az.Accounts for Get-AzVMImage
+
+        Write-Host "Installing Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Accounts -RequiredVersion 1.9.2 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
+
+
+        # Az.Compute for Connect-AzAccount
+
+        Write-Host "Installing Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Compute -RequiredVersion 4.2.1 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
+
+
+        # Az.Resources for Get-AzResource
+
+        Write-Host "Installing Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Resources -RequiredVersion 2.4.0 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
+
+
+        # Az for Azure Modules
+
+        Write-Host "Installing Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az -RequiredVersion 4.5.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
+
+
+        # Pester for Testing
+
+        Write-Host "Installing Module Pester RequiredVersion 5.0.3" | Out-Default | Write-Verbose
+
+        Install-Module -Name Pester -RequiredVersion 5.0.3 -AllowClobber -Force
+
+        Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
+
+
+        $Env:PsModuleInstalled = 'True'
+      errorActionPreference: continue
+  - task: PowerShell@2
+    displayName: Azure Login
+    inputs:
+      filePath: scripts/AzureLogin.ps1
+      arguments: -CloudAccount $(azureUserId) -CloudSecret (ConvertTo-SecureString "$(clientSecret)" -AsPlainText -force)
+      workingDirectory: scripts
+  - task: PowerShell@2
+    name: BuildImage
+    displayName: Build Image
+    timeoutInMinutes: 120
+    inputs:
+      filePath: scripts/bake-scalable-azure-image-pipeline.ps1
+      arguments: -VersionText 'w16d142$(VersionText-w16d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2016-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      workingDirectory: scripts
+  - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
+    displayName: Azure Resource Group Tagging
+    continueOnError: True
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      ResourceGroupName: BakingDP-w16d142$(VersionText-w16d-14-2)$(Build.BuildNumber)
+      Key: Usage
+      Value: test-temp
+  - task: PowerShell@2
+    displayName: 'Generate: Image URL'
+    inputs:
+      targetType: inline
+      script: >-
+        Write-Host "Writing the Full Image URL $(BuildImage.ImageUrl) in the $(Build.ArtifactStagingDirectory)" | Out-Default | Write-Host
+
+        Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w16d-14-2.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
+
+        Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
+  - task: PowerShell@2
+    displayName: VM Tests
+    inputs:
+      filePath: scripts/invoke-pester-tests.ps1
+      script: >-
+        # Invoke Pester Tests
+
+        cd $(System.DefaultWorkingDirectory)\Tests
+
+        $result = Invoke-Pester -Script '.\Image*' -OutputFormat  NUnitXml -OutputFile '$(System.DefaultWorkingDirectory)\Test-Vm.xml' -PassThru
+
+        $result | Out-Default | Write-Host
+
+        if ($result.Result -eq "Failed") {
+            throw "Failed Tests Count: $($result.FailedCount)"
+        } else {
+            Write-Host "Tested the image successfully."
+        }
+  - task: PublishTestResults@2
+    displayName: Publish Test Results **/Test-*.xml
+    inputs:
+      testRunner: NUnit
+      testResultsFiles: '**/Test-*.xml'
+      testRunTitle: w16d-14-2
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: Image URL'
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)/w16d-14-2.txt
+      ArtifactName: w16d-14-2
+      FileCopyOptions: ''
+  - task: AzureResourceManagerTemplateDeployment@3
+    displayName: Delete Resource Group
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
+      action: DeleteRG
+      resourceGroupName: BakingDP-w16d142$(VersionText-w16d-14-2)$(Build.BuildNumber)
+- job: Job_4
+  displayName: 'Agent job : w16d-15-0'
+  timeoutInMinutes: 360
+  condition: and(succeeded(), or(eq(variables['Build-w16d-15-0'], 'True'), eq(variables['Build-all'], 'True')))
+  pool:
+    vmImage: windows-2019
+  steps:
+  - checkout: self
+    fetchTags: false
+  - task: PowerShell@2
+    displayName: Install PS Module
+    inputs:
+      filePath: scripts/install-powershell-modules-azure.ps1
+      script: >-
+        if ("$(GitBranch)".Contains("refs/heads")) {
+            $branch ="$(GitBranch)".replace("refs/heads/", "")
+        } else {
+            $branch = "$(GitBranchPR)"
+        }
+
+        $branch | Write-Host | Out-Default | Write-Verbose
+
+        Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
+
+        if ($Env:PsModuleInstalled -eq 'True') {
+            Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
+            return;
+        }
+
+
+        Write-Host "Installing Module AzureRM" | Out-Default | Write-Verbose
+
+        Install-Module -Name AzureRM -AllowClobber -Force
+
+        Write-Host "Installed Module AzureRM" | Out-Default | Write-Verbose
+
+
+        Write-Host "Installing Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.KeyVault -RequiredVersion 2.0.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
+
+
+        # Az.Accounts for Get-AzVMImage
+
+        Write-Host "Installing Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Accounts -RequiredVersion 1.9.2 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
+
+
+        # Az.Compute for Connect-AzAccount
+
+        Write-Host "Installing Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Compute -RequiredVersion 4.2.1 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
+
+
+        # Az.Resources for Get-AzResource
+
+        Write-Host "Installing Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Resources -RequiredVersion 2.4.0 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
+
+
+        # Az for Azure Modules
+
+        Write-Host "Installing Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az -RequiredVersion 4.5.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
+
+
+        # Pester for Testing
+
+        Write-Host "Installing Module Pester RequiredVersion 5.0.3" | Out-Default | Write-Verbose
+
+        Install-Module -Name Pester -RequiredVersion 5.0.3 -AllowClobber -Force
+
+        Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
+
+
+        $Env:PsModuleInstalled = 'True'
+      errorActionPreference: continue
+  - task: PowerShell@2
+    displayName: Azure Login
+    inputs:
+      filePath: scripts/AzureLogin.ps1
+      arguments: -CloudAccount $(azureUserId) -CloudSecret (ConvertTo-SecureString "$(clientSecret)" -AsPlainText -force)
+      workingDirectory: scripts
+  - task: PowerShell@2
+    name: BuildImage
+    displayName: Build Image
+    timeoutInMinutes: 120
+    inputs:
+      filePath: scripts/bake-scalable-azure-image-pipeline.ps1
+      arguments: -VersionText 'w16d150$(VersionText-w16d-15-0)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2016-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      workingDirectory: scripts
+  - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
+    displayName: Azure Resource Group Tagging
+    continueOnError: True
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      ResourceGroupName: BakingDP-w16d150$(VersionText-w16d-15-0)$(Build.BuildNumber)
+      Key: Usage
+      Value: test-temp
+  - task: PowerShell@2
+    displayName: 'Generate: Image URL'
+    inputs:
+      targetType: inline
+      script: >-
+        Write-Host "Writing the Full Image URL $(BuildImage.ImageUrl) in the $(Build.ArtifactStagingDirectory)" | Out-Default | Write-Host
+
+        Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w16d-15-0.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
+
+        Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
+  - task: PowerShell@2
+    displayName: VM Tests
+    inputs:
+      filePath: scripts/invoke-pester-tests.ps1
+      script: >-
+        # Invoke Pester Tests
+
+        cd $(System.DefaultWorkingDirectory)\Tests
+
+        $result = Invoke-Pester -Script '.\Image*' -OutputFormat  NUnitXml -OutputFile '$(System.DefaultWorkingDirectory)\Test-Vm.xml' -PassThru
+
+        $result | Out-Default | Write-Host
+
+        if ($result.Result -eq "Failed") {
+            throw "Failed Tests Count: $($result.FailedCount)"
+        } else {
+            Write-Host "Tested the image successfully."
+        }
+  - task: PublishTestResults@2
+    displayName: Publish Test Results **/Test-*.xml
+    inputs:
+      testRunner: NUnit
+      testResultsFiles: '**/Test-*.xml'
+      testRunTitle: w16d-15-0
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: Image URL'
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)/w16d-15-0.txt
+      ArtifactName: w16d-15-0
+      FileCopyOptions: ''
+  - task: AzureResourceManagerTemplateDeployment@3
+    displayName: Delete Resource Group
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
+      action: DeleteRG
+      resourceGroupName: BakingDP-w16d150$(VersionText-w16d-15-0)$(Build.BuildNumber)
+- job: Job_3
+  displayName: 'Agent job : w19d-14-2'
+  timeoutInMinutes: 360
+  condition: and(succeeded(), or(eq(variables['Build-w19d-14-2'], 'True'), eq(variables['Build-all'], 'True')))
+  pool:
+    vmImage: windows-2019
+  steps:
+  - checkout: self
+    fetchTags: false
+  - task: PowerShell@2
+    displayName: Install PS Module
+    inputs:
+      filePath: scripts/install-powershell-modules-azure.ps1
+      script: >-
+        if ("$(GitBranch)".Contains("refs/heads")) {
+            $branch ="$(GitBranch)".replace("refs/heads/", "")
+        } else {
+            $branch = "$(GitBranchPR)"
+        }
+
+        $branch | Write-Host | Out-Default | Write-Verbose
+
+        Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
+
+        if ($Env:PsModuleInstalled -eq 'True') {
+            Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
+            return;
+        }
+
+
+        Write-Host "Installing Module AzureRM" | Out-Default | Write-Verbose
+
+        Install-Module -Name AzureRM -AllowClobber -Force
+
+        Write-Host "Installed Module AzureRM" | Out-Default | Write-Verbose
+
+
+        Write-Host "Installing Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.KeyVault -RequiredVersion 2.0.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
+
+
+        # Az.Accounts for Get-AzVMImage
+
+        Write-Host "Installing Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Accounts -RequiredVersion 1.9.2 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
+
+
+        # Az.Compute for Connect-AzAccount
+
+        Write-Host "Installing Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Compute -RequiredVersion 4.2.1 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
+
+
+        # Az.Resources for Get-AzResource
+
+        Write-Host "Installing Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Resources -RequiredVersion 2.4.0 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
+
+
+        # Az for Azure Modules
+
+        Write-Host "Installing Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az -RequiredVersion 4.5.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
+
+
+        # Pester for Testing
+
+        Write-Host "Installing Module Pester RequiredVersion 5.0.3" | Out-Default | Write-Verbose
+
+        Install-Module -Name Pester -RequiredVersion 5.0.3 -AllowClobber -Force
+
+        Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
+
+
+        $Env:PsModuleInstalled = 'True'
+      errorActionPreference: continue
+  - task: PowerShell@2
+    displayName: Azure Login
+    inputs:
+      filePath: scripts/AzureLogin.ps1
+      arguments: -CloudAccount $(azureUserId) -CloudSecret (ConvertTo-SecureString "$(clientSecret)" -AsPlainText -force)
+      workingDirectory: scripts
+  - task: PowerShell@2
+    name: BuildImage
+    displayName: Build Image
+    timeoutInMinutes: 120
+    inputs:
+      filePath: scripts/bake-scalable-azure-image-pipeline.ps1
+      arguments: -VersionText 'w19d142$(VersionText-w19d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      workingDirectory: scripts
+  - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
+    displayName: Azure Resource Group Tagging
+    continueOnError: True
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      ResourceGroupName: BakingDP-w19d142$(VersionText-w19d-14-2)$(Build.BuildNumber)
+      Key: Usage
+      Value: test-temp
+  - task: PowerShell@2
+    displayName: 'Generate: Image URL'
+    inputs:
+      targetType: inline
+      script: >-
+        Write-Host "Writing the Full Image URL $(BuildImage.ImageUrl) in the $(Build.ArtifactStagingDirectory)" | Out-Default | Write-Host
+
+        Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w19d-14-2.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
+
+        Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
+  - task: PowerShell@2
+    displayName: VM Tests
+    inputs:
+      filePath: scripts/invoke-pester-tests.ps1
+      script: >-
+        # Invoke Pester Tests
+
+        cd $(System.DefaultWorkingDirectory)\Tests
+
+        $result = Invoke-Pester -Script '.\Image*' -OutputFormat  NUnitXml -OutputFile '$(System.DefaultWorkingDirectory)\Test-Vm.xml' -PassThru
+
+        $result | Out-Default | Write-Host
+
+        if ($result.Result -eq "Failed") {
+            throw "Failed Tests Count: $($result.FailedCount)"
+        } else {
+            Write-Host "Tested the image successfully."
+        }
+  - task: PublishTestResults@2
+    displayName: Publish Test Results **/Test-*.xml
+    inputs:
+      testRunner: NUnit
+      testResultsFiles: '**/Test-*.xml'
+      testRunTitle: w19d-14-2
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: Image URL'
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)/w19d-14-2.txt
+      ArtifactName: w19d-14-2
+      FileCopyOptions: ''
+  - task: AzureResourceManagerTemplateDeployment@3
+    displayName: Delete Resource Group
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
+      action: DeleteRG
+      resourceGroupName: BakingDP-w19d142$(VersionText-w19d-14-2)$(Build.BuildNumber)
+- job: Job_2
+  displayName: 'Agent job : w19d-15-0'
+  timeoutInMinutes: 360
+  condition: and(succeeded(), or(eq(variables['Build-w19d-15-0'], 'True'), eq(variables['Build-all'], 'True')))
+  pool:
+    vmImage: windows-2019
+  steps:
+  - checkout: self
+    fetchTags: false
+  - task: PowerShell@2
+    displayName: Install PS Module
+    inputs:
+      filePath: scripts/install-powershell-modules-azure.ps1
+      script: >-
+        if ("$(GitBranch)".Contains("refs/heads")) {
+            $branch ="$(GitBranch)".replace("refs/heads/", "")
+        } else {
+            $branch = "$(GitBranchPR)"
+        }
+
+        $branch | Write-Host | Out-Default | Write-Verbose
+
+        Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
+
+        if ($Env:PsModuleInstalled -eq 'True') {
+            Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
+            return;
+        }
+
+
+        Write-Host "Installing Module AzureRM" | Out-Default | Write-Verbose
+
+        Install-Module -Name AzureRM -AllowClobber -Force
+
+        Write-Host "Installed Module AzureRM" | Out-Default | Write-Verbose
+
+
+        Write-Host "Installing Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.KeyVault -RequiredVersion 2.0.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
+
+
+        # Az.Accounts for Get-AzVMImage
+
+        Write-Host "Installing Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Accounts -RequiredVersion 1.9.2 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
+
+
+        # Az.Compute for Connect-AzAccount
+
+        Write-Host "Installing Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Compute -RequiredVersion 4.2.1 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
+
+
+        # Az.Resources for Get-AzResource
+
+        Write-Host "Installing Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Resources -RequiredVersion 2.4.0 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
+
+
+        # Az for Azure Modules
+
+        Write-Host "Installing Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az -RequiredVersion 4.5.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
+
+
+        # Pester for Testing
+
+        Write-Host "Installing Module Pester RequiredVersion 5.0.3" | Out-Default | Write-Verbose
+
+        Install-Module -Name Pester -RequiredVersion 5.0.3 -AllowClobber -Force
+
+        Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
+
+
+        $Env:PsModuleInstalled = 'True'
+      errorActionPreference: continue
+  - task: PowerShell@2
+    displayName: Azure Login
+    inputs:
+      filePath: scripts/AzureLogin.ps1
+      arguments: -CloudAccount $(azureUserId) -CloudSecret (ConvertTo-SecureString "$(clientSecret)" -AsPlainText -force)
+      workingDirectory: scripts
+  - task: PowerShell@2
+    name: BuildImage
+    displayName: Build Image
+    timeoutInMinutes: 120
+    inputs:
+      filePath: scripts/bake-scalable-azure-image-pipeline.ps1
+      arguments: -VersionText 'w19d150$(VersionText-w19d-15-0)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      workingDirectory: scripts
+  - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
+    displayName: Azure Resource Group Tagging
+    continueOnError: True
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      ResourceGroupName: BakingDP-w19d150$(VersionText-w19d-15-0)$(Build.BuildNumber)
+      Key: Usage
+      Value: test-temp
+  - task: PowerShell@2
+    displayName: 'Generate: Image URL'
+    inputs:
+      targetType: inline
+      script: >-
+        Write-Host "Writing the Full Image URL $(BuildImage.ImageUrl) in the $(Build.ArtifactStagingDirectory)" | Out-Default | Write-Host
+
+        Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w19d-15-0.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
+
+        Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
+  - task: PowerShell@2
+    displayName: VM Tests
+    inputs:
+      filePath: scripts/invoke-pester-tests.ps1
+      script: >-
+        # Invoke Pester Tests
+
+        cd $(System.DefaultWorkingDirectory)\Tests
+
+        $result = Invoke-Pester -Script '.\Image*' -OutputFormat  NUnitXml -OutputFile '$(System.DefaultWorkingDirectory)\Test-Vm.xml' -PassThru
+
+        $result | Out-Default | Write-Host
+
+        if ($result.Result -eq "Failed") {
+            throw "Failed Tests Count: $($result.FailedCount)"
+        } else {
+            Write-Host "Tested the image successfully."
+        }
+  - task: PublishTestResults@2
+    displayName: Publish Test Results **/Test-*.xml
+    inputs:
+      testRunner: NUnit
+      testResultsFiles: '**/Test-*.xml'
+      testRunTitle: w19d-15-0
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: Image URL'
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)/w19d-15-0.txt
+      ArtifactName: w19d-15-0
+      FileCopyOptions: ''
+  - task: AzureResourceManagerTemplateDeployment@3
+    displayName: Delete Resource Group
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
+      action: DeleteRG
+      resourceGroupName: BakingDP-w19d150$(VersionText-w19d-15-0)$(Build.BuildNumber)
+- job: Job_7
+  displayName: 'Agent job : w16d-14-2j'
+  timeoutInMinutes: 360
+  condition: and(succeeded(), or(eq(variables['Build-w16d-14-2j'], 'True'), eq(variables['Build-all'], 'True')))
+  pool:
+    vmImage: windows-2019
+  steps:
+  - checkout: self
+    fetchTags: false
+  - task: PowerShell@2
+    displayName: Install PS Module
+    inputs:
+      filePath: scripts/install-powershell-modules-azure.ps1
+      script: >-
+        if ("$(GitBranch)".Contains("refs/heads")) {
+            $branch ="$(GitBranch)".replace("refs/heads/", "")
+        } else {
+            $branch = "$(GitBranchPR)"
+        }
+
+        $branch | Write-Host | Out-Default | Write-Verbose
+
+        Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
+
+        if ($Env:PsModuleInstalled -eq 'True') {
+            Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
+            return;
+        }
+
+
+        Write-Host "Installing Module AzureRM" | Out-Default | Write-Verbose
+
+        Install-Module -Name AzureRM -AllowClobber -Force
+
+        Write-Host "Installed Module AzureRM" | Out-Default | Write-Verbose
+
+
+        Write-Host "Installing Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.KeyVault -RequiredVersion 2.0.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
+
+
+        # Az.Accounts for Get-AzVMImage
+
+        Write-Host "Installing Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Accounts -RequiredVersion 1.9.2 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
+
+
+        # Az.Compute for Connect-AzAccount
+
+        Write-Host "Installing Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Compute -RequiredVersion 4.2.1 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
+
+
+        # Az.Resources for Get-AzResource
+
+        Write-Host "Installing Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Resources -RequiredVersion 2.4.0 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
+
+
+        # Az for Azure Modules
+
+        Write-Host "Installing Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az -RequiredVersion 4.5.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
+
+
+        # Pester for Testing
+
+        Write-Host "Installing Module Pester RequiredVersion 5.0.3" | Out-Default | Write-Verbose
+
+        Install-Module -Name Pester -RequiredVersion 5.0.3 -AllowClobber -Force
+
+        Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
+
+
+        $Env:PsModuleInstalled = 'True'
+      errorActionPreference: continue
+  - task: PowerShell@2
+    displayName: Azure Login
+    inputs:
+      filePath: scripts/AzureLogin.ps1
+      arguments: -CloudAccount $(azureUserId) -CloudSecret (ConvertTo-SecureString "$(clientSecret)" -AsPlainText -force)
+      workingDirectory: scripts
+  - task: PowerShell@2
+    name: BuildImage
+    displayName: Build Image
+    timeoutInMinutes: 120
+    inputs:
+      filePath: scripts/bake-scalable-azure-image-pipeline.ps1
+      arguments: -VersionText 'w16d142j$(VersionText-w16d-14-2j)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2016-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      workingDirectory: scripts
+  - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
+    displayName: Azure Resource Group Tagging
+    continueOnError: True
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      ResourceGroupName: BakingDP-w16d142j$(VersionText-w16d-14-2j)$(Build.BuildNumber)
+      Key: Usage
+      Value: test-temp
+  - task: PowerShell@2
+    displayName: 'Generate: Image URL'
+    inputs:
+      targetType: inline
+      script: >-
+        Write-Host "Writing the Full Image URL $(BuildImage.ImageUrl) in the $(Build.ArtifactStagingDirectory)" | Out-Default | Write-Host
+
+        Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w16d-14-2j.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
+
+        Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
+  - task: PowerShell@2
+    displayName: VM Tests
+    inputs:
+      filePath: scripts/invoke-pester-tests.ps1
+      script: >-
+        # Invoke Pester Tests
+
+        cd $(System.DefaultWorkingDirectory)\Tests
+
+        $result = Invoke-Pester -Script '.\Image*' -OutputFormat  NUnitXml -OutputFile '$(System.DefaultWorkingDirectory)\Test-Vm.xml' -PassThru
+
+        $result | Out-Default | Write-Host
+
+        if ($result.Result -eq "Failed") {
+            throw "Failed Tests Count: $($result.FailedCount)"
+        } else {
+            Write-Host "Tested the image successfully."
+        }
+  - task: PublishTestResults@2
+    displayName: Publish Test Results **/Test-*.xml
+    inputs:
+      testRunner: NUnit
+      testResultsFiles: '**/Test-*.xml'
+      testRunTitle: w16d-14-2j
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: Image URL'
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)/w16d-14-2j.txt
+      ArtifactName: w16d-14-2j
+      FileCopyOptions: ''
+  - task: AzureResourceManagerTemplateDeployment@3
+    displayName: Delete Resource Group
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
+      action: DeleteRG
+      resourceGroupName: BakingDP-w16d142j$(VersionText-w16d-14-2j)$(Build.BuildNumber)
+- job: Job_8
+  displayName: 'Agent job : w16d-15-0j'
+  timeoutInMinutes: 360
+  condition: and(succeeded(), or(eq(variables['Build-w16d-15-0j'], 'True'), eq(variables['Build-all'], 'True')))
+  pool:
+    vmImage: windows-2019
+  steps:
+  - checkout: self
+    fetchTags: false
+  - task: PowerShell@2
+    displayName: Install PS Module
+    inputs:
+      filePath: scripts/install-powershell-modules-azure.ps1
+      script: >-
+        if ("$(GitBranch)".Contains("refs/heads")) {
+            $branch ="$(GitBranch)".replace("refs/heads/", "")
+        } else {
+            $branch = "$(GitBranchPR)"
+        }
+
+        $branch | Write-Host | Out-Default | Write-Verbose
+
+        Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
+
+        if ($Env:PsModuleInstalled -eq 'True') {
+            Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
+            return;
+        }
+
+
+        Write-Host "Installing Module AzureRM" | Out-Default | Write-Verbose
+
+        Install-Module -Name AzureRM -AllowClobber -Force
+
+        Write-Host "Installed Module AzureRM" | Out-Default | Write-Verbose
+
+
+        Write-Host "Installing Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.KeyVault -RequiredVersion 2.0.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
+
+
+        # Az.Accounts for Get-AzVMImage
+
+        Write-Host "Installing Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Accounts -RequiredVersion 1.9.2 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
+
+
+        # Az.Compute for Connect-AzAccount
+
+        Write-Host "Installing Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Compute -RequiredVersion 4.2.1 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
+
+
+        # Az.Resources for Get-AzResource
+
+        Write-Host "Installing Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Resources -RequiredVersion 2.4.0 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
+
+
+        # Az for Azure Modules
+
+        Write-Host "Installing Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az -RequiredVersion 4.5.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
+
+
+        # Pester for Testing
+
+        Write-Host "Installing Module Pester RequiredVersion 5.0.3" | Out-Default | Write-Verbose
+
+        Install-Module -Name Pester -RequiredVersion 5.0.3 -AllowClobber -Force
+
+        Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
+
+
+        $Env:PsModuleInstalled = 'True'
+      errorActionPreference: continue
+  - task: PowerShell@2
+    displayName: Azure Login
+    inputs:
+      filePath: scripts/AzureLogin.ps1
+      arguments: -CloudAccount $(azureUserId) -CloudSecret (ConvertTo-SecureString "$(clientSecret)" -AsPlainText -force)
+      workingDirectory: scripts
+  - task: PowerShell@2
+    name: BuildImage
+    displayName: Build Image
+    timeoutInMinutes: 120
+    inputs:
+      filePath: scripts/bake-scalable-azure-image-pipeline.ps1
+      arguments: -VersionText 'w16d150j$(VersionText-w16d-15-0j)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2016-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      workingDirectory: scripts
+  - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
+    displayName: Azure Resource Group Tagging
+    continueOnError: True
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      ResourceGroupName: BakingDP-w16d150j$(VersionText-w16d-15-0j)$(Build.BuildNumber)
+      Key: Usage
+      Value: test-temp
+  - task: PowerShell@2
+    displayName: 'Generate: Image URL'
+    inputs:
+      targetType: inline
+      script: >-
+        Write-Host "Writing the Full Image URL $(BuildImage.ImageUrl) in the $(Build.ArtifactStagingDirectory)" | Out-Default | Write-Host
+
+        Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w16d-15-0j.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
+
+        Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
+  - task: PowerShell@2
+    displayName: VM Tests
+    inputs:
+      filePath: scripts/invoke-pester-tests.ps1
+      script: >-
+        # Invoke Pester Tests
+
+        cd $(System.DefaultWorkingDirectory)\Tests
+
+        $result = Invoke-Pester -Script '.\Image*' -OutputFormat  NUnitXml -OutputFile '$(System.DefaultWorkingDirectory)\Test-Vm.xml' -PassThru
+
+        $result | Out-Default | Write-Host
+
+        if ($result.Result -eq "Failed") {
+            throw "Failed Tests Count: $($result.FailedCount)"
+        } else {
+            Write-Host "Tested the image successfully."
+        }
+  - task: PublishTestResults@2
+    displayName: Publish Test Results **/Test-*.xml
+    inputs:
+      testRunner: NUnit
+      testResultsFiles: '**/Test-*.xml'
+      testRunTitle: w16d-15-0j
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: Image URL'
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)/w16d-15-0j.txt
+      ArtifactName: w16d-15-0j
+      FileCopyOptions: ''
+  - task: AzureResourceManagerTemplateDeployment@3
+    displayName: Delete Resource Group
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
+      action: DeleteRG
+      resourceGroupName: BakingDP-w16d150j$(VersionText-w16d-15-0j)$(Build.BuildNumber)
+- job: Job_9
+  displayName: 'Agent job : w19d-15-0j'
+  timeoutInMinutes: 360
+  condition: and(succeeded(), or(eq(variables['Build-w19d-15-0j'], 'True'), eq(variables['Build-all'], 'True')))
+  pool:
+    vmImage: windows-2019
+  steps:
+  - checkout: self
+    fetchTags: false
+  - task: PowerShell@2
+    displayName: Install PS Module
+    inputs:
+      filePath: scripts/install-powershell-modules-azure.ps1
+      script: >-
+        if ("$(GitBranch)".Contains("refs/heads")) {
+            $branch ="$(GitBranch)".replace("refs/heads/", "")
+        } else {
+            $branch = "$(GitBranchPR)"
+        }
+
+        $branch | Write-Host | Out-Default | Write-Verbose
+
+        Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
+
+        if ($Env:PsModuleInstalled -eq 'True') {
+            Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
+            return;
+        }
+
+
+        Write-Host "Installing Module AzureRM" | Out-Default | Write-Verbose
+
+        Install-Module -Name AzureRM -AllowClobber -Force
+
+        Write-Host "Installed Module AzureRM" | Out-Default | Write-Verbose
+
+
+        Write-Host "Installing Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.KeyVault -RequiredVersion 2.0.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
+
+
+        # Az.Accounts for Get-AzVMImage
+
+        Write-Host "Installing Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Accounts -RequiredVersion 1.9.2 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
+
+
+        # Az.Compute for Connect-AzAccount
+
+        Write-Host "Installing Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Compute -RequiredVersion 4.2.1 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
+
+
+        # Az.Resources for Get-AzResource
+
+        Write-Host "Installing Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Resources -RequiredVersion 2.4.0 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
+
+
+        # Az for Azure Modules
+
+        Write-Host "Installing Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az -RequiredVersion 4.5.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
+
+
+        # Pester for Testing
+
+        Write-Host "Installing Module Pester RequiredVersion 5.0.3" | Out-Default | Write-Verbose
+
+        Install-Module -Name Pester -RequiredVersion 5.0.3 -AllowClobber -Force
+
+        Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
+
+
+        $Env:PsModuleInstalled = 'True'
+      errorActionPreference: continue
+  - task: PowerShell@2
+    displayName: Azure Login
+    inputs:
+      filePath: scripts/AzureLogin.ps1
+      arguments: -CloudAccount $(azureUserId) -CloudSecret (ConvertTo-SecureString "$(clientSecret)" -AsPlainText -force)
+      workingDirectory: scripts
+  - task: PowerShell@2
+    name: BuildImage
+    displayName: Build Image
+    timeoutInMinutes: 120
+    inputs:
+      filePath: scripts/bake-scalable-azure-image-pipeline.ps1
+      arguments: -VersionText 'w19d150j$(VersionText-w19d-15-0j)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      workingDirectory: scripts
+  - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
+    displayName: Azure Resource Group Tagging
+    continueOnError: True
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      ResourceGroupName: BakingDP-w19d150j$(VersionText-w19d-15-0j)$(Build.BuildNumber)
+      Key: Usage
+      Value: test-temp
+  - task: PowerShell@2
+    displayName: 'Generate: Image URL'
+    inputs:
+      targetType: inline
+      script: >-
+        Write-Host "Writing the Full Image URL $(BuildImage.ImageUrl) in the $(Build.ArtifactStagingDirectory)" | Out-Default | Write-Host
+
+        Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w19d-15-0j.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
+
+        Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
+  - task: PowerShell@2
+    displayName: VM Tests
+    inputs:
+      filePath: scripts/invoke-pester-tests.ps1
+      script: >-
+        # Invoke Pester Tests
+
+        cd $(System.DefaultWorkingDirectory)\Tests
+
+        $result = Invoke-Pester -Script '.\Image*' -OutputFormat  NUnitXml -OutputFile '$(System.DefaultWorkingDirectory)\Test-Vm.xml' -PassThru
+
+        $result | Out-Default | Write-Host
+
+        if ($result.Result -eq "Failed") {
+            throw "Failed Tests Count: $($result.FailedCount)"
+        } else {
+            Write-Host "Tested the image successfully."
+        }
+  - task: PublishTestResults@2
+    displayName: Publish Test Results **/Test-*.xml
+    inputs:
+      testRunner: NUnit
+      testResultsFiles: '**/Test-*.xml'
+      testRunTitle: w19d-15-0j
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: Image URL'
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)/w19d-15-0j.txt
+      ArtifactName: w19d-15-0j
+      FileCopyOptions: ''
+  - task: AzureResourceManagerTemplateDeployment@3
+    displayName: Delete Resource Group
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
+      action: DeleteRG
+      resourceGroupName: BakingDP-w19d150j$(VersionText-w19d-15-0j)$(Build.BuildNumber)
+- job: Job_10
+  displayName: 'Agent job : w19d-14-2j'
+  timeoutInMinutes: 360
+  condition: and(succeeded(), or(eq(variables['Build-w19d-14-2j'], 'True'), eq(variables['Build-all'], 'True')))
+  pool:
+    vmImage: windows-2019
+  steps:
+  - checkout: self
+    fetchTags: false
+  - task: PowerShell@2
+    displayName: Install PS Module
+    inputs:
+      filePath: scripts/install-powershell-modules-azure.ps1
+      script: >-
+        if ("$(GitBranch)".Contains("refs/heads")) {
+            $branch ="$(GitBranch)".replace("refs/heads/", "")
+        } else {
+            $branch = "$(GitBranchPR)"
+        }
+
+        $branch | Write-Host | Out-Default | Write-Verbose
+
+        Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
+
+        if ($Env:PsModuleInstalled -eq 'True') {
+            Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
+            return;
+        }
+
+
+        Write-Host "Installing Module AzureRM" | Out-Default | Write-Verbose
+
+        Install-Module -Name AzureRM -AllowClobber -Force
+
+        Write-Host "Installed Module AzureRM" | Out-Default | Write-Verbose
+
+
+        Write-Host "Installing Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.KeyVault -RequiredVersion 2.0.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
+
+
+        # Az.Accounts for Get-AzVMImage
+
+        Write-Host "Installing Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Accounts -RequiredVersion 1.9.2 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
+
+
+        # Az.Compute for Connect-AzAccount
+
+        Write-Host "Installing Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Compute -RequiredVersion 4.2.1 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
+
+
+        # Az.Resources for Get-AzResource
+
+        Write-Host "Installing Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az.Resources -RequiredVersion 2.4.0 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
+
+
+        # Az for Azure Modules
+
+        Write-Host "Installing Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
+
+        Install-Module -Name Az -RequiredVersion 4.5.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
+
+        Write-Host "Installed Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
+
+
+        # Pester for Testing
+
+        Write-Host "Installing Module Pester RequiredVersion 5.0.3" | Out-Default | Write-Verbose
+
+        Install-Module -Name Pester -RequiredVersion 5.0.3 -AllowClobber -Force
+
+        Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
+
+
+        $Env:PsModuleInstalled = 'True'
+      errorActionPreference: continue
+  - task: PowerShell@2
+    displayName: Azure Login
+    inputs:
+      filePath: scripts/AzureLogin.ps1
+      arguments: -CloudAccount $(azureUserId) -CloudSecret (ConvertTo-SecureString "$(clientSecret)" -AsPlainText -force)
+      workingDirectory: scripts
+  - task: PowerShell@2
+    name: BuildImage
+    displayName: Build Image
+    timeoutInMinutes: 120
+    inputs:
+      filePath: scripts/bake-scalable-azure-image-pipeline.ps1
+      arguments: -VersionText 'w19d142j$(VersionText-w19d-14-2j)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName  $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      workingDirectory: scripts
+  - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
+    displayName: Azure Resource Group Tagging
+    continueOnError: True
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      ResourceGroupName: BakingDP-w19d142j$(VersionText-w19d-14-2j)$(Build.BuildNumber)
+      Key: Usage
+      Value: test-temp
+  - task: PowerShell@2
+    displayName: 'Generate: Image URL'
+    inputs:
+      targetType: inline
+      script: >-
+        Write-Host "Writing the Full Image URL $(BuildImage.ImageUrl) in the $(Build.ArtifactStagingDirectory)" | Out-Default | Write-Host
+
+        Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w19d-14-2j.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
+
+        Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
+  - task: PowerShell@2
+    displayName: VM Tests
+    inputs:
+      filePath: scripts/invoke-pester-tests.ps1
+      script: >-
+        # Invoke Pester Tests
+
+        cd $(System.DefaultWorkingDirectory)\Tests
+
+        $result = Invoke-Pester -Script '.\Image*' -OutputFormat  NUnitXml -OutputFile '$(System.DefaultWorkingDirectory)\Test-Vm.xml' -PassThru
+
+        $result | Out-Default | Write-Host
+
+        if ($result.Result -eq "Failed") {
+            throw "Failed Tests Count: $($result.FailedCount)"
+        } else {
+            Write-Host "Tested the image successfully."
+        }
+  - task: PublishTestResults@2
+    displayName: Publish Test Results **/Test-*.xml
+    inputs:
+      testRunner: NUnit
+      testResultsFiles: '**/Test-*.xml'
+      testRunTitle: w19d-14-2j
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: Image URL'
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)/w19d-14-2j.txt
+      ArtifactName: w19d-14-2j
+      FileCopyOptions: ''
+  - task: AzureResourceManagerTemplateDeployment@3
+    displayName: Delete Resource Group
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
+      action: DeleteRG
+      resourceGroupName: BakingDP-w19d142j$(VersionText-w19d-14-2j)$(Build.BuildNumber)
+...

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -192,7 +192,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d142$(VersionText-w19d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText '$(VersionText-w19d-14-2)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -28,7 +28,7 @@ jobs:
   - name:  Build-all
     value: False
   - name: Build-w12r2d-14-2
-    value: False
+    value: True
   - name: Build-w12r2d-15-0
     value: False
   - name: Build-w16d-14-2

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -92,7 +92,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d142$(VersionText-w19d-14-2)$(Build.BuildId)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -GitUserName $(GitUserName) -ExternalIPAddresses $(ExternalIPAddresses)
+      arguments: -VersionText 'w19d-14-2$(VersionText-w19d-14-2)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -GitUserName $(GitUserName) -ExternalIPAddresses $(ExternalIPAddresses)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -263,7 +263,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w22d150$(VersionText-w22d-15-0)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2012-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w22d-15-0$(VersionText-w22d-15-0)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2012-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -432,7 +432,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w16d142$(VersionText-w16d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2016-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w16d-14-2$(VersionText-w16d-14-2)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2016-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -601,7 +601,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w16d150$(VersionText-w16d-15-0)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2016-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w16d-15-0$(VersionText-w16d-15-0)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2016-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -770,7 +770,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d142$(VersionText-w19d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w19d-14-2$(VersionText-w19d-14-2 -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -939,7 +939,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d150$(VersionText-w19d-15-0)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w19d-15-0$(VersionText-w19d-15-0)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -1108,7 +1108,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w16d142j$(VersionText-w16d-14-2j)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2016-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w16d-14-2j$(VersionText-w16d-14-2j)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2016-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -1277,7 +1277,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w16d150j$(VersionText-w16d-15-0j)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2016-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w16d-15-0j$(VersionText-w16d-15-0j)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2016-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -1446,7 +1446,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d150j$(VersionText-w19d-15-0j)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w19d-15-0j$(VersionText-w19d-15-0j)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -1615,7 +1615,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d142j$(VersionText-w19d-14-2j)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName  $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w19d-14-2j$(VersionText-w19d-14-2j)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName  $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -1784,7 +1784,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w22d150j$(VersionText-w22d-15-0j)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2022-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w22d-15-0j$(VersionText-w22d-15-0j)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2022-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -1953,7 +1953,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w22d142j$(VersionText-w22d-14-2j)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName  $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w22d-14-2j$(VersionText-w22d-14-2j)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName  $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -8,7 +8,7 @@ resources:
   repositories:
   - repository: self
     type: git
-    ref: refs/heads/debug/paas
+    ref: feature/priyanka-classic2YAML
 
 variables: 
   - group: 'External IP Addresses'
@@ -182,7 +182,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w12r2d142$(VersionText-w12r2d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2012-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w12r2d142$(VersionText-w12r2d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2012-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
@@ -344,7 +344,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w12r2d150$(VersionText-w12r2d-15-0)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2012-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w12r2d150$(VersionText-w12r2d-15-0)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2012-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
@@ -504,7 +504,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w16d142$(VersionText-w16d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2016-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w16d142$(VersionText-w16d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2016-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
@@ -664,7 +664,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w16d150$(VersionText-w16d-15-0)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2016-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w16d150$(VersionText-w16d-15-0)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2016-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps']) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
@@ -824,7 +824,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d142$(VersionText-w19d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w19d142$(VersionText-w19d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
@@ -984,7 +984,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d150$(VersionText-w19d-15-0)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w19d150$(VersionText-w19d-15-0)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
@@ -1144,7 +1144,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w16d142j$(VersionText-w16d-14-2j)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2016-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w16d142j$(VersionText-w16d-14-2j)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2016-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
@@ -1304,7 +1304,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w16d150j$(VersionText-w16d-15-0j)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2016-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w16d150j$(VersionText-w16d-15-0j)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2016-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
@@ -1464,7 +1464,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d150j$(VersionText-w19d-15-0j)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w19d150j$(VersionText-w19d-15-0j)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
@@ -1624,7 +1624,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d142j$(VersionText-w19d-14-2j)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName  $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w19d142j$(VersionText-w19d-14-2j)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName  $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -18,7 +18,6 @@ variables:
     value: feature/priyanka-classic2YAML
   - name: GitUserName
     value: priyadishah
-    value: $false
   - name: JpnLanguage
     value: ENG
   - name: quickstart-scripts

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -96,89 +96,14 @@ jobs:
   steps:
   - checkout: self
     fetchTags: false
+
   - task: PowerShell@2
     name: ''
     displayName: Install PS Module
     inputs:
       filePath: scripts/install-powershell-modules-azure.ps1
-      script: >-
-        if ("$(GitBranch)".Contains("refs/heads")) {
-            $branch ="$(GitBranch)".replace("refs/heads/", "")
-        } else {
-            $branch = "$(GitBranchPR)"
-        }
-
-        $branch | Write-Host | Out-Default | Write-Verbose
-
-        Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
-
-        if ($Env:PsModuleInstalled -eq 'true') {
-            Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
-            return;
-        }
-
-
-        Write-Host "Installing Module AzureRM" | Out-Default | Write-Verbose
-
-        Install-Module -Name AzureRM -AllowClobber -Force
-
-        Write-Host "Installed Module AzureRM" | Out-Default | Write-Verbose
-
-
-        Write-Host "Installing Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.KeyVault -RequiredVersion 2.0.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
-
-
-        # Az.Accounts for Get-AzVMImage
-
-        Write-Host "Installing Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Accounts -RequiredVersion 1.9.2 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
-
-
-        # Az.Compute for Connect-AzAccount
-
-        Write-Host "Installing Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Compute -RequiredVersion 4.2.1 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
-
-
-        # Az.Resources for Get-AzResource
-
-        Write-Host "Installing Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Resources -RequiredVersion 2.4.0 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
-
-
-        # Az for Azure Modules
-
-        Write-Host "Installing Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az -RequiredVersion 4.5.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
-
-
-        # Pester for Testing
-
-        Write-Host "Installing Module Pester RequiredVersion 5.6.1" | Out-Default | Write-Verbose
-
-        Install-Module -Name Pester -RequiredVersion 5.6.1 -AllowClobber -Force
-
-        Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
-
-
-        $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
+
   - task: PowerShell@2
     name: ''
     displayName: Azure Login
@@ -186,6 +111,7 @@ jobs:
       filePath: scripts/AzureLogin.ps1
       arguments: -CloudAccount $(azureUserId) -CloudSecret (ConvertTo-SecureString "$(clientSecret)" -AsPlainText -force)
       workingDirectory: scripts
+
   - task: PowerShell@2
     name: BuildImage
     displayName: Build Image
@@ -194,13 +120,15 @@ jobs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
       arguments: -VersionText 'w19d142$(VersionText-w19d-14-2)$(Build.BuildId)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild $(atomic-build-ps) -GitUserName $(GitUserName) -ExternalIPAddresses $(ExternalIPAddresses)
       workingDirectory: scripts
+
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w22d142$(VersionText-w22d-14-2)$(Build.BuildNumber)
+      ResourceGroupName: BakingDP-w19d142$(VersionText-w19d-14-2)$(Build.BuildId)
       Key: Usage
       Value: test-temp
+
   - task: PowerShell@2
     name: ''
     displayName: 'Generate: Image URL'
@@ -212,6 +140,7 @@ jobs:
         Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w22d-14-2.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
 
         Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
+
   - task: PowerShell@2
     name: ''
     displayName: VM Tests
@@ -231,12 +160,14 @@ jobs:
         } else {
             Write-Host "Tested the image successfully."
         }
+
   - task: PublishTestResults@2
     displayName: Publish Test Results **/Test-*.xml
     inputs:
       testRunner: NUnit
       testResultsFiles: '**/Test-*.xml'
       testRunTitle: w22d-14-2
+
   - task: PublishBuildArtifacts@1
     name: ''
     displayName: 'Publish Artifact: Image URL'
@@ -244,6 +175,7 @@ jobs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/w22d-14-2.txt
       ArtifactName: w22d-14-2
       FileCopyOptions: ''
+
   - task: AzureResourceManagerTemplateDeployment@3
     displayName: Delete Resource Group
     inputs:
@@ -251,6 +183,7 @@ jobs:
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
       resourceGroupName: BakingDP-w22d142$(VersionText-w22d-14-2)$(Build.BuildNumber)
+
 - job: Job_5
   displayName: 'Agent job : w22d-15-0'
   timeoutInMinutes: 360
@@ -342,12 +275,14 @@ jobs:
 
         $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
+
   - task: PowerShell@2
     displayName: Azure Login
     inputs:
       filePath: scripts/AzureLogin.ps1
       arguments: -CloudAccount $(azureUserId) -CloudSecret (ConvertTo-SecureString "$(clientSecret)" -AsPlainText -force)
       workingDirectory: scripts
+
   - task: PowerShell@2
     name: BuildImage
     displayName: Build Image
@@ -356,6 +291,7 @@ jobs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
       arguments: -VersionText 'w22d150$(VersionText-w22d-15-0)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2012-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
+
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
     continueOnError: true
@@ -364,6 +300,7 @@ jobs:
       ResourceGroupName: BakingDP-w22d150$(VersionText-w22d-15-0)$(Build.BuildNumber)
       Key: Usage
       Value: test-temp
+
   - task: PowerShell@2
     displayName: 'Generate: Image URL'
     inputs:
@@ -374,6 +311,7 @@ jobs:
         Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w22d-15-0.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
 
         Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
+
   - task: PowerShell@2
     displayName: VM Tests
     inputs:
@@ -392,18 +330,21 @@ jobs:
         } else {
             Write-Host "Tested the image successfully."
         }
+
   - task: PublishTestResults@2
     displayName: Publish Test Results **/Test-*.xml
     inputs:
       testRunner: NUnit
       testResultsFiles: '**/Test-*.xml'
       testRunTitle: w22d-15-0
+
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: Image URL'
     inputs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/w22d-15-0.txt
       ArtifactName: w22d-15-0
       FileCopyOptions: ''
+
   - task: AzureResourceManagerTemplateDeployment@3
     displayName: Delete Resource Group
     inputs:
@@ -411,6 +352,7 @@ jobs:
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
       resourceGroupName: BakingDP-w22d150$(VersionText-w22d-15-0)$(Build.BuildNumber)
+
 - job: Job_6
   displayName: 'Agent job : w16d-14-2'
   timeoutInMinutes: 360
@@ -502,12 +444,14 @@ jobs:
 
         $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
+
   - task: PowerShell@2
     displayName: Azure Login
     inputs:
       filePath: scripts/AzureLogin.ps1
       arguments: -CloudAccount $(azureUserId) -CloudSecret (ConvertTo-SecureString "$(clientSecret)" -AsPlainText -force)
       workingDirectory: scripts
+
   - task: PowerShell@2
     name: BuildImage
     displayName: Build Image
@@ -516,6 +460,7 @@ jobs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
       arguments: -VersionText 'w16d142$(VersionText-w16d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2016-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
+
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
     continueOnError: true
@@ -524,6 +469,7 @@ jobs:
       ResourceGroupName: BakingDP-w16d142$(VersionText-w16d-14-2)$(Build.BuildNumber)
       Key: Usage
       Value: test-temp
+
   - task: PowerShell@2
     displayName: 'Generate: Image URL'
     inputs:
@@ -534,6 +480,7 @@ jobs:
         Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w16d-14-2.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
 
         Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
+
   - task: PowerShell@2
     displayName: VM Tests
     inputs:
@@ -552,18 +499,21 @@ jobs:
         } else {
             Write-Host "Tested the image successfully."
         }
+
   - task: PublishTestResults@2
     displayName: Publish Test Results **/Test-*.xml
     inputs:
       testRunner: NUnit
       testResultsFiles: '**/Test-*.xml'
       testRunTitle: w16d-14-2
+
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: Image URL'
     inputs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/w16d-14-2.txt
       ArtifactName: w16d-14-2
       FileCopyOptions: ''
+
   - task: AzureResourceManagerTemplateDeployment@3
     displayName: Delete Resource Group
     inputs:
@@ -571,6 +521,7 @@ jobs:
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
       resourceGroupName: BakingDP-w16d142$(VersionText-w16d-14-2)$(Build.BuildNumber)
+
 - job: Job_4
   displayName: 'Agent job : w16d-15-0'
   timeoutInMinutes: 360
@@ -662,12 +613,14 @@ jobs:
 
         $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
+
   - task: PowerShell@2
     displayName: Azure Login
     inputs:
       filePath: scripts/AzureLogin.ps1
       arguments: -CloudAccount $(azureUserId) -CloudSecret (ConvertTo-SecureString "$(clientSecret)" -AsPlainText -force)
       workingDirectory: scripts
+
   - task: PowerShell@2
     name: BuildImage
     displayName: Build Image
@@ -676,6 +629,7 @@ jobs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
       arguments: -VersionText 'w16d150$(VersionText-w16d-15-0)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2016-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps']) -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
+
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
     continueOnError: true
@@ -684,6 +638,7 @@ jobs:
       ResourceGroupName: BakingDP-w16d150$(VersionText-w16d-15-0)$(Build.BuildNumber)
       Key: Usage
       Value: test-temp
+
   - task: PowerShell@2
     displayName: 'Generate: Image URL'
     inputs:
@@ -694,6 +649,7 @@ jobs:
         Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w16d-15-0.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
 
         Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
+
   - task: PowerShell@2
     displayName: VM Tests
     inputs:
@@ -712,18 +668,21 @@ jobs:
         } else {
             Write-Host "Tested the image successfully."
         }
+
   - task: PublishTestResults@2
     displayName: Publish Test Results **/Test-*.xml
     inputs:
       testRunner: NUnit
       testResultsFiles: '**/Test-*.xml'
       testRunTitle: w16d-15-0
+
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: Image URL'
     inputs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/w16d-15-0.txt
       ArtifactName: w16d-15-0
       FileCopyOptions: ''
+
   - task: AzureResourceManagerTemplateDeployment@3
     displayName: Delete Resource Group
     inputs:
@@ -731,6 +690,7 @@ jobs:
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
       resourceGroupName: BakingDP-w16d150$(VersionText-w16d-15-0)$(Build.BuildNumber)
+
 - job: Job_3
   displayName: 'Agent job : w19d-14-2'
   timeoutInMinutes: 360
@@ -822,12 +782,14 @@ jobs:
 
         $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
+
   - task: PowerShell@2
     displayName: Azure Login
     inputs:
       filePath: scripts/AzureLogin.ps1
       arguments: -CloudAccount $(azureUserId) -CloudSecret (ConvertTo-SecureString "$(clientSecret)" -AsPlainText -force)
       workingDirectory: scripts
+
   - task: PowerShell@2
     name: BuildImage
     displayName: Build Image
@@ -836,6 +798,7 @@ jobs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
       arguments: -VersionText 'w19d142$(VersionText-w19d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
+
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
     continueOnError: true
@@ -844,6 +807,7 @@ jobs:
       ResourceGroupName: BakingDP-w19d142$(VersionText-w19d-14-2)$(Build.BuildNumber)
       Key: Usage
       Value: test-temp
+
   - task: PowerShell@2
     displayName: 'Generate: Image URL'
     inputs:
@@ -854,6 +818,7 @@ jobs:
         Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w19d-14-2.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
 
         Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
+
   - task: PowerShell@2
     displayName: VM Tests
     inputs:
@@ -872,18 +837,21 @@ jobs:
         } else {
             Write-Host "Tested the image successfully."
         }
+
   - task: PublishTestResults@2
     displayName: Publish Test Results **/Test-*.xml
     inputs:
       testRunner: NUnit
       testResultsFiles: '**/Test-*.xml'
       testRunTitle: w19d-14-2
+
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: Image URL'
     inputs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/w19d-14-2.txt
       ArtifactName: w19d-14-2
       FileCopyOptions: ''
+
   - task: AzureResourceManagerTemplateDeployment@3
     displayName: Delete Resource Group
     inputs:
@@ -891,6 +859,7 @@ jobs:
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
       resourceGroupName: BakingDP-w19d142$(VersionText-w19d-14-2)$(Build.BuildNumber)
+
 - job: Job_2
   displayName: 'Agent job : w19d-15-0'
   timeoutInMinutes: 360
@@ -982,12 +951,14 @@ jobs:
 
         $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
+
   - task: PowerShell@2
     displayName: Azure Login
     inputs:
       filePath: scripts/AzureLogin.ps1
       arguments: -CloudAccount $(azureUserId) -CloudSecret (ConvertTo-SecureString "$(clientSecret)" -AsPlainText -force)
       workingDirectory: scripts
+
   - task: PowerShell@2
     name: BuildImage
     displayName: Build Image
@@ -996,6 +967,7 @@ jobs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
       arguments: -VersionText 'w19d150$(VersionText-w19d-15-0)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
+
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
     continueOnError: true
@@ -1004,6 +976,7 @@ jobs:
       ResourceGroupName: BakingDP-w19d150$(VersionText-w19d-15-0)$(Build.BuildNumber)
       Key: Usage
       Value: test-temp
+
   - task: PowerShell@2
     displayName: 'Generate: Image URL'
     inputs:
@@ -1014,6 +987,7 @@ jobs:
         Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w19d-15-0.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
 
         Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
+
   - task: PowerShell@2
     displayName: VM Tests
     inputs:
@@ -1032,18 +1006,21 @@ jobs:
         } else {
             Write-Host "Tested the image successfully."
         }
+
   - task: PublishTestResults@2
     displayName: Publish Test Results **/Test-*.xml
     inputs:
       testRunner: NUnit
       testResultsFiles: '**/Test-*.xml'
       testRunTitle: w19d-15-0
+
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: Image URL'
     inputs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/w19d-15-0.txt
       ArtifactName: w19d-15-0
       FileCopyOptions: ''
+
   - task: AzureResourceManagerTemplateDeployment@3
     displayName: Delete Resource Group
     inputs:
@@ -1051,6 +1028,7 @@ jobs:
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
       resourceGroupName: BakingDP-w19d150$(VersionText-w19d-15-0)$(Build.BuildNumber)
+
 - job: Job_7
   displayName: 'Agent job : w16d-14-2j'
   timeoutInMinutes: 360
@@ -1142,12 +1120,14 @@ jobs:
 
         $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
+
   - task: PowerShell@2
     displayName: Azure Login
     inputs:
       filePath: scripts/AzureLogin.ps1
       arguments: -CloudAccount $(azureUserId) -CloudSecret (ConvertTo-SecureString "$(clientSecret)" -AsPlainText -force)
       workingDirectory: scripts
+
   - task: PowerShell@2
     name: BuildImage
     displayName: Build Image
@@ -1156,6 +1136,7 @@ jobs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
       arguments: -VersionText 'w16d142j$(VersionText-w16d-14-2j)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2016-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
+
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
     continueOnError: true
@@ -1164,6 +1145,7 @@ jobs:
       ResourceGroupName: BakingDP-w16d142j$(VersionText-w16d-14-2j)$(Build.BuildNumber)
       Key: Usage
       Value: test-temp
+
   - task: PowerShell@2
     displayName: 'Generate: Image URL'
     inputs:
@@ -1174,6 +1156,7 @@ jobs:
         Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w16d-14-2j.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
 
         Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
+
   - task: PowerShell@2
     displayName: VM Tests
     inputs:
@@ -1192,18 +1175,21 @@ jobs:
         } else {
             Write-Host "Tested the image successfully."
         }
+
   - task: PublishTestResults@2
     displayName: Publish Test Results **/Test-*.xml
     inputs:
       testRunner: NUnit
       testResultsFiles: '**/Test-*.xml'
       testRunTitle: w16d-14-2j
+
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: Image URL'
     inputs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/w16d-14-2j.txt
       ArtifactName: w16d-14-2j
       FileCopyOptions: ''
+
   - task: AzureResourceManagerTemplateDeployment@3
     displayName: Delete Resource Group
     inputs:
@@ -1211,6 +1197,7 @@ jobs:
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
       resourceGroupName: BakingDP-w16d142j$(VersionText-w16d-14-2j)$(Build.BuildNumber)
+
 - job: Job_8
   displayName: 'Agent job : w16d-15-0j'
   timeoutInMinutes: 360
@@ -1302,12 +1289,14 @@ jobs:
 
         $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
+
   - task: PowerShell@2
     displayName: Azure Login
     inputs:
       filePath: scripts/AzureLogin.ps1
       arguments: -CloudAccount $(azureUserId) -CloudSecret (ConvertTo-SecureString "$(clientSecret)" -AsPlainText -force)
       workingDirectory: scripts
+
   - task: PowerShell@2
     name: BuildImage
     displayName: Build Image
@@ -1316,6 +1305,7 @@ jobs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
       arguments: -VersionText 'w16d150j$(VersionText-w16d-15-0j)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2016-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
+
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
     continueOnError: true
@@ -1324,6 +1314,7 @@ jobs:
       ResourceGroupName: BakingDP-w16d150j$(VersionText-w16d-15-0j)$(Build.BuildNumber)
       Key: Usage
       Value: test-temp
+
   - task: PowerShell@2
     displayName: 'Generate: Image URL'
     inputs:
@@ -1334,6 +1325,7 @@ jobs:
         Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w16d-15-0j.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
 
         Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
+
   - task: PowerShell@2
     displayName: VM Tests
     inputs:
@@ -1352,18 +1344,21 @@ jobs:
         } else {
             Write-Host "Tested the image successfully."
         }
+
   - task: PublishTestResults@2
     displayName: Publish Test Results **/Test-*.xml
     inputs:
       testRunner: NUnit
       testResultsFiles: '**/Test-*.xml'
       testRunTitle: w16d-15-0j
+
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: Image URL'
     inputs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/w16d-15-0j.txt
       ArtifactName: w16d-15-0j
       FileCopyOptions: ''
+
   - task: AzureResourceManagerTemplateDeployment@3
     displayName: Delete Resource Group
     inputs:
@@ -1371,6 +1366,7 @@ jobs:
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
       resourceGroupName: BakingDP-w16d150j$(VersionText-w16d-15-0j)$(Build.BuildNumber)
+
 - job: Job_9
   displayName: 'Agent job : w19d-15-0j'
   timeoutInMinutes: 360
@@ -1462,12 +1458,14 @@ jobs:
 
         $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
+
   - task: PowerShell@2
     displayName: Azure Login
     inputs:
       filePath: scripts/AzureLogin.ps1
       arguments: -CloudAccount $(azureUserId) -CloudSecret (ConvertTo-SecureString "$(clientSecret)" -AsPlainText -force)
       workingDirectory: scripts
+
   - task: PowerShell@2
     name: BuildImage
     displayName: Build Image
@@ -1476,6 +1474,7 @@ jobs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
       arguments: -VersionText 'w19d150j$(VersionText-w19d-15-0j)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
+
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
     continueOnError: true
@@ -1484,6 +1483,7 @@ jobs:
       ResourceGroupName: BakingDP-w19d150j$(VersionText-w19d-15-0j)$(Build.BuildNumber)
       Key: Usage
       Value: test-temp
+
   - task: PowerShell@2
     displayName: 'Generate: Image URL'
     inputs:
@@ -1494,6 +1494,7 @@ jobs:
         Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w19d-15-0j.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
 
         Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
+
   - task: PowerShell@2
     displayName: VM Tests
     inputs:
@@ -1512,18 +1513,21 @@ jobs:
         } else {
             Write-Host "Tested the image successfully."
         }
+
   - task: PublishTestResults@2
     displayName: Publish Test Results **/Test-*.xml
     inputs:
       testRunner: NUnit
       testResultsFiles: '**/Test-*.xml'
       testRunTitle: w19d-15-0j
+
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: Image URL'
     inputs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/w19d-15-0j.txt
       ArtifactName: w19d-15-0j
       FileCopyOptions: ''
+
   - task: AzureResourceManagerTemplateDeployment@3
     displayName: Delete Resource Group
     inputs:
@@ -1531,6 +1535,7 @@ jobs:
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
       resourceGroupName: BakingDP-w19d150j$(VersionText-w19d-15-0j)$(Build.BuildNumber)
+
 - job: Job_10
   displayName: 'Agent job : w19d-14-2j'
   timeoutInMinutes: 360
@@ -1622,12 +1627,14 @@ jobs:
 
         $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
+
   - task: PowerShell@2
     displayName: Azure Login
     inputs:
       filePath: scripts/AzureLogin.ps1
       arguments: -CloudAccount $(azureUserId) -CloudSecret (ConvertTo-SecureString "$(clientSecret)" -AsPlainText -force)
       workingDirectory: scripts
+
   - task: PowerShell@2
     name: BuildImage
     displayName: Build Image
@@ -1636,6 +1643,7 @@ jobs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
       arguments: -VersionText 'w19d142j$(VersionText-w19d-14-2j)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName  $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
+
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
     continueOnError: true
@@ -1644,6 +1652,7 @@ jobs:
       ResourceGroupName: BakingDP-w19d142j$(VersionText-w19d-14-2j)$(Build.BuildNumber)
       Key: Usage
       Value: test-temp
+
   - task: PowerShell@2
     displayName: 'Generate: Image URL'
     inputs:
@@ -1654,6 +1663,7 @@ jobs:
         Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w19d-14-2j.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
 
         Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
+
   - task: PowerShell@2
     displayName: VM Tests
     inputs:
@@ -1672,18 +1682,21 @@ jobs:
         } else {
             Write-Host "Tested the image successfully."
         }
+
   - task: PublishTestResults@2
     displayName: Publish Test Results **/Test-*.xml
     inputs:
       testRunner: NUnit
       testResultsFiles: '**/Test-*.xml'
       testRunTitle: w19d-14-2j
+
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: Image URL'
     inputs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/w19d-14-2j.txt
       ArtifactName: w19d-14-2j
       FileCopyOptions: ''
+
   - task: AzureResourceManagerTemplateDeployment@3
     displayName: Delete Resource Group
     inputs:
@@ -1691,6 +1704,7 @@ jobs:
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
       resourceGroupName: BakingDP-w19d142j$(VersionText-w19d-14-2j)$(Build.BuildNumber)
+
 - job: Job_11
   displayName: 'Agent job : w22d-15-0j'
   timeoutInMinutes: 360
@@ -1782,12 +1796,14 @@ jobs:
 
         $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
+
   - task: PowerShell@2
     displayName: Azure Login
     inputs:
       filePath: scripts/AzureLogin.ps1
       arguments: -CloudAccount $(azureUserId) -CloudSecret (ConvertTo-SecureString "$(clientSecret)" -AsPlainText -force)
       workingDirectory: scripts
+
   - task: PowerShell@2
     name: BuildImage
     displayName: Build Image
@@ -1796,6 +1812,7 @@ jobs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
       arguments: -VersionText 'w22d150j$(VersionText-w22d-15-0j)$(Build.BuildNumber)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2022-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
+
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
     continueOnError: true
@@ -1804,6 +1821,7 @@ jobs:
       ResourceGroupName: BakingDP-w22d150j$(VersionText-w22d-15-0j)$(Build.BuildNumber)
       Key: Usage
       Value: test-temp
+
   - task: PowerShell@2
     displayName: 'Generate: Image URL'
     inputs:
@@ -1814,6 +1832,7 @@ jobs:
         Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w22d-15-0j.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
 
         Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
+
   - task: PowerShell@2
     displayName: VM Tests
     inputs:
@@ -1832,18 +1851,21 @@ jobs:
         } else {
             Write-Host "Tested the image successfully."
         }
+
   - task: PublishTestResults@2
     displayName: Publish Test Results **/Test-*.xml
     inputs:
       testRunner: NUnit
       testResultsFiles: '**/Test-*.xml'
       testRunTitle: w22d-15-0j
+
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: Image URL'
     inputs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/w22d-15-0j.txt
       ArtifactName: w22d-15-0j
       FileCopyOptions: ''
+
   - task: AzureResourceManagerTemplateDeployment@3
     displayName: Delete Resource Group
     inputs:
@@ -1851,6 +1873,7 @@ jobs:
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
       resourceGroupName: BakingDP-w19d150j$(VersionText-w19d-15-0j)$(Build.BuildNumber)
+
 - job: Job_12
   displayName: 'Agent job : w22d-14-2j'
   timeoutInMinutes: 360
@@ -1942,12 +1965,14 @@ jobs:
 
         $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
+
   - task: PowerShell@2
     displayName: Azure Login
     inputs:
       filePath: scripts/AzureLogin.ps1
       arguments: -CloudAccount $(azureUserId) -CloudSecret (ConvertTo-SecureString "$(clientSecret)" -AsPlainText -force)
       workingDirectory: scripts
+
   - task: PowerShell@2
     name: BuildImage
     displayName: Build Image
@@ -1956,6 +1981,7 @@ jobs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
       arguments: -VersionText 'w22d142j$(VersionText-w22d-14-2j)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName  $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
+
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
     continueOnError: true
@@ -1964,6 +1990,7 @@ jobs:
       ResourceGroupName: BakingDP-w22d142j$(VersionText-w22d-14-2j)$(Build.BuildNumber)
       Key: Usage
       Value: test-temp
+
   - task: PowerShell@2
     displayName: 'Generate: Image URL'
     inputs:
@@ -1974,6 +2001,7 @@ jobs:
         Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "w22d-14-2j.txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
 
         Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
+
   - task: PowerShell@2
     displayName: VM Tests
     inputs:
@@ -1992,18 +2020,21 @@ jobs:
         } else {
             Write-Host "Tested the image successfully."
         }
+
   - task: PublishTestResults@2
     displayName: Publish Test Results **/Test-*.xml
     inputs:
       testRunner: NUnit
       testResultsFiles: '**/Test-*.xml'
       testRunTitle: w22d-14-2j
+
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: Image URL'
     inputs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/w22d-14-2j.txt
       ArtifactName: w22d-14-2j
       FileCopyOptions: ''
+      
   - task: AzureResourceManagerTemplateDeployment@3
     displayName: Delete Resource Group
     inputs:

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -1614,7 +1614,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d-14-2j-$(VersionText-w19d-14-2j)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName  $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w19d-14-2j-$(VersionText-w19d-14-2j)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName  $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -1783,7 +1783,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w22d-15-0j-$(VersionText-w22d-15-0j)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2022-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w22d-15-0j-$(VersionText-w22d-15-0j)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2022-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -118,6 +118,11 @@ jobs:
   - task: PowerShell@2
     name: ''
     displayName: VM Tests
+    env:
+    TestImageName: w22d142$(VersionText-w22d-14-2)$(Build.BuildNumber)
+    TestCloudName: Azure
+    AtomicBuild: $(atomic-build)
+    TestVmName: Test22142$(VersionText-w22d-14-2)$(Build.BuildNumber)
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
       script: >-
@@ -288,6 +293,11 @@ jobs:
 
   - task: PowerShell@2
     displayName: VM Tests
+    env:
+    TestImageName: w22d150$(VersionText-w22d-15-0)$(Build.BuildNumber)
+    TestCloudName: Azure
+    AtomicBuild: $(atomic-build)
+    TestVmName: Test22150$(VersionText-w22d-15-0)$(Build.BuildNumber)
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
       script: >-
@@ -457,6 +467,11 @@ jobs:
 
   - task: PowerShell@2
     displayName: VM Tests
+    env:
+        TestImageName: w16d142$(VersionText-w16d-14-2)$(Build.BuildNumber)
+        TestCloudName: Azure
+        AtomicBuild: $(atomic-build)
+        TestVmName: Test16142$(VersionText-w16d-14-2)$(Build.BuildNumber)
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
       script: >-
@@ -626,6 +641,11 @@ jobs:
 
   - task: PowerShell@2
     displayName: VM Tests
+    env:
+        TestImageName: w16d150$(VersionText-w16d-15-0)$(Build.BuildNumber)
+        TestCloudName: Azure
+        AtomicBuild: $(atomic-build)
+        TestVmName: Test16150$(VersionText-w16d-15-0)$(Build.BuildNumber)
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
       script: >-
@@ -795,6 +815,11 @@ jobs:
 
   - task: PowerShell@2
     displayName: VM Tests
+    env:
+        TestImageName: w19d142$(VersionText-w19d-14-2)$(Build.BuildNumber)
+        TestCloudName: Azure
+        AtomicBuild: $(atomic-build)
+        TestVmName: Test19142$(VersionText-w19d-14-2)$(Build.BuildNumber)
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
       script: >-
@@ -964,6 +989,11 @@ jobs:
 
   - task: PowerShell@2
     displayName: VM Tests
+    env:
+        TestImageName: w19d150$(VersionText-w19d-15-0)$(Build.BuildNumber)
+        TestCloudName: Azure
+        AtomicBuild: $(atomic-build)
+        TestVmName: Test19150$(VersionText-w19d-15-0)$(Build.BuildNumber)
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
       script: >-
@@ -1133,6 +1163,11 @@ jobs:
 
   - task: PowerShell@2
     displayName: VM Tests
+    env:
+        TestImageName: w16d142j$(VersionText-w16d-14-2j)$(Build.BuildNumber)
+        TestCloudName: Azure
+        AtomicBuild: $(atomic-build)
+        TestVmName: Test16142j$(VersionText-w16d-14-2j)$(Build.BuildNumber)
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
       script: >-
@@ -1302,6 +1337,11 @@ jobs:
 
   - task: PowerShell@2
     displayName: VM Tests
+    env:
+        TestImageName: w16d150j$(VersionText-w16d-15-0j)$(Build.BuildNumber)
+        TestCloudName: Azure
+        AtomicBuild: $(atomic-build)
+        TestVmName: Test16150j$(VersionText-w16d-15-0j)$(Build.BuildNumber)
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
       script: >-
@@ -1470,6 +1510,11 @@ jobs:
 
   - task: PowerShell@2
     displayName: VM Tests
+    env:
+        TestImageName: w19d150j$(VersionText-w19d-15-0j)$(Build.BuildNumber)
+        TestCloudName: Azure
+        AtomicBuild: $(atomic-build)
+        TestVmName: Test19150j$(VersionText-w19d-15-0j)$(Build.BuildNumber)
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
       script: >-
@@ -1639,6 +1684,11 @@ jobs:
 
   - task: PowerShell@2
     displayName: VM Tests
+    env:
+        TestImageName: w19d142j$(VersionText-w19d-14-2j)$(Build.BuildNumber)
+        TestCloudName: Azure
+        AtomicBuild: $(atomic-build)
+        TestVmName: Test19142j$(VersionText-w19d-14-2j)$(Build.BuildNumber)
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
       script: >-
@@ -1808,6 +1858,11 @@ jobs:
 
   - task: PowerShell@2
     displayName: VM Tests
+    env:
+        TestImageName: w22d150j$(VersionText-w22d-15-0j)$(Build.BuildNumber)
+        TestCloudName: Azure
+        AtomicBuild: $(atomic-build)
+        TestVmName: Test22150j$(VersionText-w22d-15-0j)$(Build.BuildNumber)
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
       script: >-
@@ -1977,6 +2032,11 @@ jobs:
 
   - task: PowerShell@2
     displayName: VM Tests
+    env:
+        TestImageName: w22d142j$(VersionText-w22d-14-2j)$(Build.BuildNumber)
+        TestCloudName: Azure
+        AtomicBuild: $(atomic-build)
+        TestVmName: Test22142j$(VersionText-w22d-14-2j)$(Build.BuildNumber)
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
       script: >-

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -23,15 +23,15 @@ variables:
   - name:  Build-all
     value: false
   - name: Build-w22d-14-2
-    value: false
+    value: true
   - name: Build-w22d-15-0
     value: false
   - name: Build-w22d-14-2j
-    value: true
+    value: false
   - name: Build-w22d-15-0j
     value: false  
   - name: Build-w16d-14-2
-    value: true
+    value: false
   - name: Build-w16d-14-2j
     value: false
   - name: Build-w16d-15-0
@@ -43,7 +43,7 @@ variables:
   - name: Build-w19d-14-2j
     value: false
   - name: Build-w19d-15-0
-    value: true
+    value: false
   - name: Build-w19d-15-0j
     value: false
   # - name: clientsecret

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -16,8 +16,8 @@ variables:
   - group: 'Azure Logins'
   - name: atomic-build
     value: $False
-  - name: atomic-build-ps
-    value: $False
+  # - name: atomic-build-ps
+  #   value: $False
   - name: azureUserId
     value: PowershellScriptsSP
   - name:  Build-all
@@ -192,7 +192,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w22d142$(VersionText-w22d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w22d142$(VersionText-w22d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild ${env:ATOMIC-BUILD-PS} -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -15,9 +15,9 @@ variables:
   - group: 'Image Names'
   - group: 'Azure Logins'
   - name: atomic-build
-    value: false
+    value: $false
   - name: atomic-build-ps
-    value: false
+    value: $false
   - name: azureUserId
     value: PowershellScriptsSP
   - name:  Build-all

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -16,12 +16,8 @@ variables:
   - group: 'Azure Logins'
   - name: atomic-build
     value: $False
-  # - name: atomic-build-ps
-  #   value: $False
   - name: azureUserId
     value: PowershellScriptsSP
-  # - name: clientsecret
-    # value: ********
   - name: GitBranch
     value: $(Build.SourceBranch)
   - name: GitBranchPR
@@ -120,21 +116,6 @@ jobs:
     displayName: VM Tests
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
-      script: >-
-        # Invoke Pester Tests
-
-        cd $(System.DefaultWorkingDirectory)\Tests
-
-        $result = Invoke-Pester -Script '.\Image*' -OutputFormat  NUnitXml -OutputFile '$(System.DefaultWorkingDirectory)\Test-Vm.xml' -PassThru
-
-        $result | Out-Default | Write-Host
-
-        if ($result.Result -eq "Failed") {
-            throw "Failed Tests Count: $($result.FailedCount)"
-        } else {
-            Write-Host "Tested the image successfully."
-        }
-
   - task: PublishTestResults@2
     displayName: Publish Test Results **/Test-*.xml
     inputs:
@@ -171,83 +152,6 @@ jobs:
     displayName: Install PS Module
     inputs:
       filePath: scripts/install-powershell-modules-azure.ps1
-      script: >-
-        if ("$(GitBranch)".Contains("refs/heads")) {
-            $branch ="$(GitBranch)".replace("refs/heads/", "")
-        } else {
-            $branch = "$(GitBranchPR)"
-        }
-
-        $branch | Write-Host | Out-Default | Write-Verbose
-
-        Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
-
-        if ($Env:PsModuleInstalled -eq 'true') {
-            Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
-            return;
-        }
-
-
-        Write-Host "Installing Module AzureRM" | Out-Default | Write-Verbose
-
-        Install-Module -Name AzureRM -AllowClobber -Force
-
-        Write-Host "Installed Module AzureRM" | Out-Default | Write-Verbose
-
-
-        Write-Host "Installing Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.KeyVault -RequiredVersion 2.0.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
-
-
-        # Az.Accounts for Get-AzVMImage
-
-        Write-Host "Installing Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Accounts -RequiredVersion 1.9.2 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
-
-
-        # Az.Compute for Connect-AzAccount
-
-        Write-Host "Installing Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Compute -RequiredVersion 4.2.1 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
-
-
-        # Az.Resources for Get-AzResource
-
-        Write-Host "Installing Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Resources -RequiredVersion 2.4.0 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
-
-
-        # Az for Azure Modules
-
-        Write-Host "Installing Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az -RequiredVersion 4.5.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
-
-
-        # Pester for Testing
-
-        Write-Host "Installing Module Pester RequiredVersion 5.6.1" | Out-Default | Write-Verbose
-
-        Install-Module -Name Pester -RequiredVersion 5.6.1 -AllowClobber -Force
-
-        Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
-
-
-        $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
 
   - task: PowerShell@2
@@ -290,20 +194,6 @@ jobs:
     displayName: VM Tests
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
-      script: >-
-        # Invoke Pester Tests
-
-        cd $(System.DefaultWorkingDirectory)\Tests
-
-        $result = Invoke-Pester -Script '.\Image*' -OutputFormat  NUnitXml -OutputFile '$(System.DefaultWorkingDirectory)\Test-Vm.xml' -PassThru
-
-        $result | Out-Default | Write-Host
-
-        if ($result.Result -eq "Failed") {
-            throw "Failed Tests Count: $($result.FailedCount)"
-        } else {
-            Write-Host "Tested the image successfully."
-        }
 
   - task: PublishTestResults@2
     displayName: Publish Test Results **/Test-*.xml
@@ -340,85 +230,7 @@ jobs:
     displayName: Install PS Module
     inputs:
       filePath: scripts/install-powershell-modules-azure.ps1
-      script: >-
-        if ("$(GitBranch)".Contains("refs/heads")) {
-            $branch ="$(GitBranch)".replace("refs/heads/", "")
-        } else {
-            $branch = "$(GitBranchPR)"
-        }
-
-        $branch | Write-Host | Out-Default | Write-Verbose
-
-        Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
-
-        if ($Env:PsModuleInstalled -eq 'true') {
-            Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
-            return;
-        }
-
-
-        Write-Host "Installing Module AzureRM" | Out-Default | Write-Verbose
-
-        Install-Module -Name AzureRM -AllowClobber -Force
-
-        Write-Host "Installed Module AzureRM" | Out-Default | Write-Verbose
-
-
-        Write-Host "Installing Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.KeyVault -RequiredVersion 2.0.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
-
-
-        # Az.Accounts for Get-AzVMImage
-
-        Write-Host "Installing Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Accounts -RequiredVersion 1.9.2 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
-
-
-        # Az.Compute for Connect-AzAccount
-
-        Write-Host "Installing Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Compute -RequiredVersion 4.2.1 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
-
-
-        # Az.Resources for Get-AzResource
-
-        Write-Host "Installing Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Resources -RequiredVersion 2.4.0 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
-
-
-        # Az for Azure Modules
-
-        Write-Host "Installing Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az -RequiredVersion 4.5.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
-
-
-        # Pester for Testing
-
-        Write-Host "Installing Module Pester RequiredVersion 5.6.1" | Out-Default | Write-Verbose
-
-        Install-Module -Name Pester -RequiredVersion 5.6.1 -AllowClobber -Force
-
-        Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
-
-
-        $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
-
   - task: PowerShell@2
     displayName: Azure Login
     inputs:
@@ -459,21 +271,7 @@ jobs:
     displayName: VM Tests
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
-      script: >-
-        # Invoke Pester Tests
-
-        cd $(System.DefaultWorkingDirectory)\Tests
-
-        $result = Invoke-Pester -Script '.\Image*' -OutputFormat  NUnitXml -OutputFile '$(System.DefaultWorkingDirectory)\Test-Vm.xml' -PassThru
-
-        $result | Out-Default | Write-Host
-
-        if ($result.Result -eq "Failed") {
-            throw "Failed Tests Count: $($result.FailedCount)"
-        } else {
-            Write-Host "Tested the image successfully."
-        }
-
+      
   - task: PublishTestResults@2
     displayName: Publish Test Results **/Test-*.xml
     inputs:
@@ -509,83 +307,6 @@ jobs:
     displayName: Install PS Module
     inputs:
       filePath: scripts/install-powershell-modules-azure.ps1
-      script: >-
-        if ("$(GitBranch)".Contains("refs/heads")) {
-            $branch ="$(GitBranch)".replace("refs/heads/", "")
-        } else {
-            $branch = "$(GitBranchPR)"
-        }
-
-        $branch | Write-Host | Out-Default | Write-Verbose
-
-        Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
-
-        if ($Env:PsModuleInstalled -eq 'true') {
-            Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
-            return;
-        }
-
-
-        Write-Host "Installing Module AzureRM" | Out-Default | Write-Verbose
-
-        Install-Module -Name AzureRM -AllowClobber -Force
-
-        Write-Host "Installed Module AzureRM" | Out-Default | Write-Verbose
-
-
-        Write-Host "Installing Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.KeyVault -RequiredVersion 2.0.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
-
-
-        # Az.Accounts for Get-AzVMImage
-
-        Write-Host "Installing Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Accounts -RequiredVersion 1.9.2 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
-
-
-        # Az.Compute for Connect-AzAccount
-
-        Write-Host "Installing Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Compute -RequiredVersion 4.2.1 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
-
-
-        # Az.Resources for Get-AzResource
-
-        Write-Host "Installing Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Resources -RequiredVersion 2.4.0 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
-
-
-        # Az for Azure Modules
-
-        Write-Host "Installing Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az -RequiredVersion 4.5.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
-
-
-        # Pester for Testing
-
-        Write-Host "Installing Module Pester RequiredVersion 5.6.1" | Out-Default | Write-Verbose
-
-        Install-Module -Name Pester -RequiredVersion 5.6.1 -AllowClobber -Force
-
-        Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
-
-
-        $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
 
   - task: PowerShell@2
@@ -628,21 +349,7 @@ jobs:
     displayName: VM Tests
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
-      script: >-
-        # Invoke Pester Tests
-
-        cd $(System.DefaultWorkingDirectory)\Tests
-
-        $result = Invoke-Pester -Script '.\Image*' -OutputFormat  NUnitXml -OutputFile '$(System.DefaultWorkingDirectory)\Test-Vm.xml' -PassThru
-
-        $result | Out-Default | Write-Host
-
-        if ($result.Result -eq "Failed") {
-            throw "Failed Tests Count: $($result.FailedCount)"
-        } else {
-            Write-Host "Tested the image successfully."
-        }
-
+  
   - task: PublishTestResults@2
     displayName: Publish Test Results **/Test-*.xml
     inputs:
@@ -678,83 +385,6 @@ jobs:
     displayName: Install PS Module
     inputs:
       filePath: scripts/install-powershell-modules-azure.ps1
-      script: >-
-        if ("$(GitBranch)".Contains("refs/heads")) {
-            $branch ="$(GitBranch)".replace("refs/heads/", "")
-        } else {
-            $branch = "$(GitBranchPR)"
-        }
-
-        $branch | Write-Host | Out-Default | Write-Verbose
-
-        Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
-
-        if ($Env:PsModuleInstalled -eq 'true') {
-            Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
-            return;
-        }
-
-
-        Write-Host "Installing Module AzureRM" | Out-Default | Write-Verbose
-
-        Install-Module -Name AzureRM -AllowClobber -Force
-
-        Write-Host "Installed Module AzureRM" | Out-Default | Write-Verbose
-
-
-        Write-Host "Installing Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.KeyVault -RequiredVersion 2.0.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
-
-
-        # Az.Accounts for Get-AzVMImage
-
-        Write-Host "Installing Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Accounts -RequiredVersion 1.9.2 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
-
-
-        # Az.Compute for Connect-AzAccount
-
-        Write-Host "Installing Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Compute -RequiredVersion 4.2.1 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
-
-
-        # Az.Resources for Get-AzResource
-
-        Write-Host "Installing Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Resources -RequiredVersion 2.4.0 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
-
-
-        # Az for Azure Modules
-
-        Write-Host "Installing Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az -RequiredVersion 4.5.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
-
-
-        # Pester for Testing
-
-        Write-Host "Installing Module Pester RequiredVersion 5.6.1" | Out-Default | Write-Verbose
-
-        Install-Module -Name Pester -RequiredVersion 5.6.1 -AllowClobber -Force
-
-        Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
-
-
-        $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
 
   - task: PowerShell@2
@@ -797,21 +427,7 @@ jobs:
     displayName: VM Tests
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
-      script: >-
-        # Invoke Pester Tests
-
-        cd $(System.DefaultWorkingDirectory)\Tests
-
-        $result = Invoke-Pester -Script '.\Image*' -OutputFormat  NUnitXml -OutputFile '$(System.DefaultWorkingDirectory)\Test-Vm.xml' -PassThru
-
-        $result | Out-Default | Write-Host
-
-        if ($result.Result -eq "Failed") {
-            throw "Failed Tests Count: $($result.FailedCount)"
-        } else {
-            Write-Host "Tested the image successfully."
-        }
-
+      
   - task: PublishTestResults@2
     displayName: Publish Test Results **/Test-*.xml
     inputs:
@@ -847,83 +463,6 @@ jobs:
     displayName: Install PS Module
     inputs:
       filePath: scripts/install-powershell-modules-azure.ps1
-      script: >-
-        if ("$(GitBranch)".Contains("refs/heads")) {
-            $branch ="$(GitBranch)".replace("refs/heads/", "")
-        } else {
-            $branch = "$(GitBranchPR)"
-        }
-
-        $branch | Write-Host | Out-Default | Write-Verbose
-
-        Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
-
-        if ($Env:PsModuleInstalled -eq 'true') {
-            Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
-            return;
-        }
-
-
-        Write-Host "Installing Module AzureRM" | Out-Default | Write-Verbose
-
-        Install-Module -Name AzureRM -AllowClobber -Force
-
-        Write-Host "Installed Module AzureRM" | Out-Default | Write-Verbose
-
-
-        Write-Host "Installing Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.KeyVault -RequiredVersion 2.0.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
-
-
-        # Az.Accounts for Get-AzVMImage
-
-        Write-Host "Installing Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Accounts -RequiredVersion 1.9.2 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
-
-
-        # Az.Compute for Connect-AzAccount
-
-        Write-Host "Installing Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Compute -RequiredVersion 4.2.1 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
-
-
-        # Az.Resources for Get-AzResource
-
-        Write-Host "Installing Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Resources -RequiredVersion 2.4.0 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
-
-
-        # Az for Azure Modules
-
-        Write-Host "Installing Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az -RequiredVersion 4.5.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
-
-
-        # Pester for Testing
-
-        Write-Host "Installing Module Pester RequiredVersion 5.6.1" | Out-Default | Write-Verbose
-
-        Install-Module -Name Pester -RequiredVersion 5.6.1 -AllowClobber -Force
-
-        Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
-
-
-        $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
 
   - task: PowerShell@2
@@ -966,21 +505,7 @@ jobs:
     displayName: VM Tests
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
-      script: >-
-        # Invoke Pester Tests
-
-        cd $(System.DefaultWorkingDirectory)\Tests
-
-        $result = Invoke-Pester -Script '.\Image*' -OutputFormat  NUnitXml -OutputFile '$(System.DefaultWorkingDirectory)\Test-Vm.xml' -PassThru
-
-        $result | Out-Default | Write-Host
-
-        if ($result.Result -eq "Failed") {
-            throw "Failed Tests Count: $($result.FailedCount)"
-        } else {
-            Write-Host "Tested the image successfully."
-        }
-
+     
   - task: PublishTestResults@2
     displayName: Publish Test Results **/Test-*.xml
     inputs:
@@ -1016,83 +541,6 @@ jobs:
     displayName: Install PS Module
     inputs:
       filePath: scripts/install-powershell-modules-azure.ps1
-      script: >-
-        if ("$(GitBranch)".Contains("refs/heads")) {
-            $branch ="$(GitBranch)".replace("refs/heads/", "")
-        } else {
-            $branch = "$(GitBranchPR)"
-        }
-
-        $branch | Write-Host | Out-Default | Write-Verbose
-
-        Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
-
-        if ($Env:PsModuleInstalled -eq 'true') {
-            Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
-            return;
-        }
-
-
-        Write-Host "Installing Module AzureRM" | Out-Default | Write-Verbose
-
-        Install-Module -Name AzureRM -AllowClobber -Force
-
-        Write-Host "Installed Module AzureRM" | Out-Default | Write-Verbose
-
-
-        Write-Host "Installing Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.KeyVault -RequiredVersion 2.0.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
-
-
-        # Az.Accounts for Get-AzVMImage
-
-        Write-Host "Installing Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Accounts -RequiredVersion 1.9.2 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
-
-
-        # Az.Compute for Connect-AzAccount
-
-        Write-Host "Installing Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Compute -RequiredVersion 4.2.1 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
-
-
-        # Az.Resources for Get-AzResource
-
-        Write-Host "Installing Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Resources -RequiredVersion 2.4.0 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
-
-
-        # Az for Azure Modules
-
-        Write-Host "Installing Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az -RequiredVersion 4.5.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
-
-
-        # Pester for Testing
-
-        Write-Host "Installing Module Pester RequiredVersion 5.6.1" | Out-Default | Write-Verbose
-
-        Install-Module -Name Pester -RequiredVersion 5.6.1 -AllowClobber -Force
-
-        Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
-
-
-        $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
 
   - task: PowerShell@2
@@ -1135,21 +583,7 @@ jobs:
     displayName: VM Tests
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
-      script: >-
-        # Invoke Pester Tests
-
-        cd $(System.DefaultWorkingDirectory)\Tests
-
-        $result = Invoke-Pester -Script '.\Image*' -OutputFormat  NUnitXml -OutputFile '$(System.DefaultWorkingDirectory)\Test-Vm.xml' -PassThru
-
-        $result | Out-Default | Write-Host
-
-        if ($result.Result -eq "Failed") {
-            throw "Failed Tests Count: $($result.FailedCount)"
-        } else {
-            Write-Host "Tested the image successfully."
-        }
-
+      
   - task: PublishTestResults@2
     displayName: Publish Test Results **/Test-*.xml
     inputs:
@@ -1185,83 +619,6 @@ jobs:
     displayName: Install PS Module
     inputs:
       filePath: scripts/install-powershell-modules-azure.ps1
-      script: >-
-        if ("$(GitBranch)".Contains("refs/heads")) {
-            $branch ="$(GitBranch)".replace("refs/heads/", "")
-        } else {
-            $branch = "$(GitBranchPR)"
-        }
-
-        $branch | Write-Host | Out-Default | Write-Verbose
-
-        Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
-
-        if ($Env:PsModuleInstalled -eq 'true') {
-            Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
-            return;
-        }
-
-
-        Write-Host "Installing Module AzureRM" | Out-Default | Write-Verbose
-
-        Install-Module -Name AzureRM -AllowClobber -Force
-
-        Write-Host "Installed Module AzureRM" | Out-Default | Write-Verbose
-
-
-        Write-Host "Installing Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.KeyVault -RequiredVersion 2.0.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
-
-
-        # Az.Accounts for Get-AzVMImage
-
-        Write-Host "Installing Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Accounts -RequiredVersion 1.9.2 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
-
-
-        # Az.Compute for Connect-AzAccount
-
-        Write-Host "Installing Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Compute -RequiredVersion 4.2.1 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
-
-
-        # Az.Resources for Get-AzResource
-
-        Write-Host "Installing Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Resources -RequiredVersion 2.4.0 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
-
-
-        # Az for Azure Modules
-
-        Write-Host "Installing Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az -RequiredVersion 4.5.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
-
-
-        # Pester for Testing
-
-        Write-Host "Installing Module Pester RequiredVersion 5.6.1" | Out-Default | Write-Verbose
-
-        Install-Module -Name Pester -RequiredVersion 5.6.1 -AllowClobber -Force
-
-        Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
-
-
-        $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
 
   - task: PowerShell@2
@@ -1304,21 +661,7 @@ jobs:
     displayName: VM Tests
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
-      script: >-
-        # Invoke Pester Tests
-
-        cd $(System.DefaultWorkingDirectory)\Tests
-
-        $result = Invoke-Pester -Script '.\Image*' -OutputFormat  NUnitXml -OutputFile '$(System.DefaultWorkingDirectory)\Test-Vm.xml' -PassThru
-
-        $result | Out-Default | Write-Host
-
-        if ($result.Result -eq "Failed") {
-            throw "Failed Tests Count: $($result.FailedCount)"
-        } else {
-            Write-Host "Tested the image successfully."
-        }
-
+      
   - task: PublishTestResults@2
     displayName: Publish Test Results **/Test-*.xml
     inputs:
@@ -1354,83 +697,6 @@ jobs:
     displayName: Install PS Module
     inputs:
       filePath: scripts/install-powershell-modules-azure.ps1
-      script: >-
-        if ("$(GitBranch)".Contains("refs/heads")) {
-            $branch ="$(GitBranch)".replace("refs/heads/", "")
-        } else {
-            $branch = "$(GitBranchPR)"
-        }
-
-        $branch | Write-Host | Out-Default | Write-Verbose
-
-        Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
-
-        if ($Env:PsModuleInstalled -eq 'true') {
-            Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
-            return;
-        }
-
-
-        Write-Host "Installing Module AzureRM" | Out-Default | Write-Verbose
-
-        Install-Module -Name AzureRM -AllowClobber -Force
-
-        Write-Host "Installed Module AzureRM" | Out-Default | Write-Verbose
-
-
-        Write-Host "Installing Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.KeyVault -RequiredVersion 2.0.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
-
-
-        # Az.Accounts for Get-AzVMImage
-
-        Write-Host "Installing Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Accounts -RequiredVersion 1.9.2 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
-
-
-        # Az.Compute for Connect-AzAccount
-
-        Write-Host "Installing Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Compute -RequiredVersion 4.2.1 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
-
-
-        # Az.Resources for Get-AzResource
-
-        Write-Host "Installing Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Resources -RequiredVersion 2.4.0 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
-
-
-        # Az for Azure Modules
-
-        Write-Host "Installing Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az -RequiredVersion 4.5.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
-
-
-        # Pester for Testing
-
-        Write-Host "Installing Module Pester RequiredVersion 5.6.1" | Out-Default | Write-Verbose
-
-        Install-Module -Name Pester -RequiredVersion 5.6.1 -AllowClobber -Force
-
-        Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
-
-
-        $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
 
   - task: PowerShell@2
@@ -1473,21 +739,7 @@ jobs:
     displayName: VM Tests
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
-      script: >-
-        # Invoke Pester Tests
-
-        cd $(System.DefaultWorkingDirectory)\Tests
-
-        $result = Invoke-Pester -Script '.\Image*' -OutputFormat  NUnitXml -OutputFile '$(System.DefaultWorkingDirectory)\Test-Vm.xml' -PassThru
-
-        $result | Out-Default | Write-Host
-
-        if ($result.Result -eq "Failed") {
-            throw "Failed Tests Count: $($result.FailedCount)"
-        } else {
-            Write-Host "Tested the image successfully."
-        }
-
+ 
   - task: PublishTestResults@2
     displayName: Publish Test Results **/Test-*.xml
     inputs:
@@ -1523,83 +775,6 @@ jobs:
     displayName: Install PS Module
     inputs:
       filePath: scripts/install-powershell-modules-azure.ps1
-      script: >-
-        if ("$(GitBranch)".Contains("refs/heads")) {
-            $branch ="$(GitBranch)".replace("refs/heads/", "")
-        } else {
-            $branch = "$(GitBranchPR)"
-        }
-
-        $branch | Write-Host | Out-Default | Write-Verbose
-
-        Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
-
-        if ($Env:PsModuleInstalled -eq 'true') {
-            Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
-            return;
-        }
-
-
-        Write-Host "Installing Module AzureRM" | Out-Default | Write-Verbose
-
-        Install-Module -Name AzureRM -AllowClobber -Force
-
-        Write-Host "Installed Module AzureRM" | Out-Default | Write-Verbose
-
-
-        Write-Host "Installing Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.KeyVault -RequiredVersion 2.0.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
-
-
-        # Az.Accounts for Get-AzVMImage
-
-        Write-Host "Installing Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Accounts -RequiredVersion 1.9.2 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
-
-
-        # Az.Compute for Connect-AzAccount
-
-        Write-Host "Installing Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Compute -RequiredVersion 4.2.1 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
-
-
-        # Az.Resources for Get-AzResource
-
-        Write-Host "Installing Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Resources -RequiredVersion 2.4.0 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
-
-
-        # Az for Azure Modules
-
-        Write-Host "Installing Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az -RequiredVersion 4.5.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
-
-
-        # Pester for Testing
-
-        Write-Host "Installing Module Pester RequiredVersion 5.6.1" | Out-Default | Write-Verbose
-
-        Install-Module -Name Pester -RequiredVersion 5.6.1 -AllowClobber -Force
-
-        Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
-
-
-        $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
 
   - task: PowerShell@2
@@ -1642,21 +817,7 @@ jobs:
     displayName: VM Tests
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
-      script: >-
-        # Invoke Pester Tests
-
-        cd $(System.DefaultWorkingDirectory)\Tests
-
-        $result = Invoke-Pester -Script '.\Image*' -OutputFormat  NUnitXml -OutputFile '$(System.DefaultWorkingDirectory)\Test-Vm.xml' -PassThru
-
-        $result | Out-Default | Write-Host
-
-        if ($result.Result -eq "Failed") {
-            throw "Failed Tests Count: $($result.FailedCount)"
-        } else {
-            Write-Host "Tested the image successfully."
-        }
-
+      
   - task: PublishTestResults@2
     displayName: Publish Test Results **/Test-*.xml
     inputs:
@@ -1692,83 +853,6 @@ jobs:
     displayName: Install PS Module
     inputs:
       filePath: scripts/install-powershell-modules-azure.ps1
-      script: >-
-        if ("$(GitBranch)".Contains("refs/heads")) {
-            $branch ="$(GitBranch)".replace("refs/heads/", "")
-        } else {
-            $branch = "$(GitBranchPR)"
-        }
-
-        $branch | Write-Host | Out-Default | Write-Verbose
-
-        Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
-
-        if ($Env:PsModuleInstalled -eq 'true') {
-            Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
-            return;
-        }
-
-
-        Write-Host "Installing Module AzureRM" | Out-Default | Write-Verbose
-
-        Install-Module -Name AzureRM -AllowClobber -Force
-
-        Write-Host "Installed Module AzureRM" | Out-Default | Write-Verbose
-
-
-        Write-Host "Installing Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.KeyVault -RequiredVersion 2.0.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
-
-
-        # Az.Accounts for Get-AzVMImage
-
-        Write-Host "Installing Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Accounts -RequiredVersion 1.9.2 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
-
-
-        # Az.Compute for Connect-AzAccount
-
-        Write-Host "Installing Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Compute -RequiredVersion 4.2.1 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
-
-
-        # Az.Resources for Get-AzResource
-
-        Write-Host "Installing Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Resources -RequiredVersion 2.4.0 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
-
-
-        # Az for Azure Modules
-
-        Write-Host "Installing Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az -RequiredVersion 4.5.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
-
-
-        # Pester for Testing
-
-        Write-Host "Installing Module Pester RequiredVersion 5.6.1" | Out-Default | Write-Verbose
-
-        Install-Module -Name Pester -RequiredVersion 5.6.1 -AllowClobber -Force
-
-        Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
-
-
-        $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
 
   - task: PowerShell@2
@@ -1811,21 +895,7 @@ jobs:
     displayName: VM Tests
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
-      script: >-
-        # Invoke Pester Tests
-
-        cd $(System.DefaultWorkingDirectory)\Tests
-
-        $result = Invoke-Pester -Script '.\Image*' -OutputFormat  NUnitXml -OutputFile '$(System.DefaultWorkingDirectory)\Test-Vm.xml' -PassThru
-
-        $result | Out-Default | Write-Host
-
-        if ($result.Result -eq "Failed") {
-            throw "Failed Tests Count: $($result.FailedCount)"
-        } else {
-            Write-Host "Tested the image successfully."
-        }
-
+   
   - task: PublishTestResults@2
     displayName: Publish Test Results **/Test-*.xml
     inputs:
@@ -1861,83 +931,6 @@ jobs:
     displayName: Install PS Module
     inputs:
       filePath: scripts/install-powershell-modules-azure.ps1
-      script: >-
-        if ("$(GitBranch)".Contains("refs/heads")) {
-            $branch ="$(GitBranch)".replace("refs/heads/", "")
-        } else {
-            $branch = "$(GitBranchPR)"
-        }
-
-        $branch | Write-Host | Out-Default | Write-Verbose
-
-        Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
-
-        if ($Env:PsModuleInstalled -eq 'true') {
-            Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
-            return;
-        }
-
-
-        Write-Host "Installing Module AzureRM" | Out-Default | Write-Verbose
-
-        Install-Module -Name AzureRM -AllowClobber -Force
-
-        Write-Host "Installed Module AzureRM" | Out-Default | Write-Verbose
-
-
-        Write-Host "Installing Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.KeyVault -RequiredVersion 2.0.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.KeyVault  -RequiredVersion 2.0.0" | Out-Default | Write-Verbose
-
-
-        # Az.Accounts for Get-AzVMImage
-
-        Write-Host "Installing Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Accounts -RequiredVersion 1.9.2 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Accounts -RequiredVersion 1.9.2" | Out-Default | Write-Verbose
-
-
-        # Az.Compute for Connect-AzAccount
-
-        Write-Host "Installing Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Compute -RequiredVersion 4.2.1 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Compute -RequiredVersion 4.2.1" | Out-Default | Write-Verbose
-
-
-        # Az.Resources for Get-AzResource
-
-        Write-Host "Installing Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az.Resources -RequiredVersion 2.4.0 -Force -AllowClobber | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az.Resources -RequiredVersion 2.4.0" | Out-Default | Write-Verbose
-
-
-        # Az for Azure Modules
-
-        Write-Host "Installing Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
-
-        Install-Module -Name Az -RequiredVersion 4.5.0 -AllowClobber -Force | Out-Default | Write-Host | Write-Verbose
-
-        Write-Host "Installed Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
-
-
-        # Pester for Testing
-
-        Write-Host "Installing Module Pester RequiredVersion 5.6.1" | Out-Default | Write-Verbose
-
-        Install-Module -Name Pester -RequiredVersion 5.6.1 -AllowClobber -Force
-
-        Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
-
-
-        $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
 
   - task: PowerShell@2
@@ -1980,21 +973,7 @@ jobs:
     displayName: VM Tests
     inputs:
       filePath: scripts/invoke-pester-tests.ps1
-      script: >-
-        # Invoke Pester Tests
-
-        cd $(System.DefaultWorkingDirectory)\Tests
-
-        $result = Invoke-Pester -Script '.\Image*' -OutputFormat  NUnitXml -OutputFile '$(System.DefaultWorkingDirectory)\Test-Vm.xml' -PassThru
-
-        $result | Out-Default | Write-Host
-
-        if ($result.Result -eq "Failed") {
-            throw "Failed Tests Count: $($result.FailedCount)"
-        } else {
-            Write-Host "Tested the image successfully."
-        }
-
+    
   - task: PublishTestResults@2
     displayName: Publish Test Results **/Test-*.xml
     inputs:

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -58,14 +58,6 @@ jobs:
     value: ENG
   - name: quickstart-scripts
     value: $(Agent.BuildDirectory)\test
-  - name: system.collectionId
-    value: 556ac44f-caae-4fef-a5b6-d964fed453e6
-  - name: system.debug
-    value: false
-  - name: system.definitionId
-    value: 30
-  - name: system.teamProject
-    value: 'Lansa Azure Scalable License Images'
   - name: VersionText-w12r2d-14-2
     value: 0
   - name: VersionText-w12r2d-15-0

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -92,14 +92,14 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d-14-2$(VersionText-w19d-14-2)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -GitUserName $(GitUserName) -ExternalIPAddresses $(ExternalIPAddresses)
+      arguments: -VersionText 'w22d-14-2$(VersionText-w22d-14-2)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -GitUserName $(GitUserName) -ExternalIPAddresses $(ExternalIPAddresses)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w19d142$(VersionText-w19d-14-2)$(Build.BuildId)
+      ResourceGroupName: BakingDP-w22d142$(VersionText-w19d-14-2)
       Key: Usage
       Value: test-temp
 
@@ -156,7 +156,7 @@ jobs:
       ConnectedServiceName: $(ConnectedServiceName)
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
-      resourceGroupName: BakingDP-w19d142$(VersionText-w19d-14-2)$(Build.BuildId)
+      resourceGroupName: BakingDP-w22d142$(VersionText-w22d-14-2)
 
 - job: Job_5
   displayName: 'Agent job : w22d-15-0'
@@ -271,7 +271,7 @@ jobs:
     continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w22d150$(VersionText-w22d-15-0)$(Build.BuildNumber)
+      ResourceGroupName: BakingDP-w22d150$(VersionText-w22d-15-0)
       Key: Usage
       Value: test-temp
 
@@ -325,7 +325,7 @@ jobs:
       ConnectedServiceName: $(ConnectedServiceName)
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
-      resourceGroupName: BakingDP-w22d150$(VersionText-w22d-15-0)$(Build.BuildNumber)
+      resourceGroupName: BakingDP-w22d150$(VersionText-w22d-15-0)
 
 - job: Job_6
   displayName: 'Agent job : w16d-14-2'
@@ -440,7 +440,7 @@ jobs:
     continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w16d142$(VersionText-w16d-14-2)$(Build.BuildNumber)
+      ResourceGroupName: BakingDP-w16d142$(VersionText-w16d-14-2)
       Key: Usage
       Value: test-temp
 
@@ -494,7 +494,7 @@ jobs:
       ConnectedServiceName: $(ConnectedServiceName)
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
-      resourceGroupName: BakingDP-w16d142$(VersionText-w16d-14-2)$(Build.BuildNumber)
+      resourceGroupName: BakingDP-w16d142$(VersionText-w16d-14-2)
 
 - job: Job_4
   displayName: 'Agent job : w16d-15-0'
@@ -609,7 +609,7 @@ jobs:
     continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w16d150$(VersionText-w16d-15-0)$(Build.BuildNumber)
+      ResourceGroupName: BakingDP-w16d150$(VersionText-w16d-15-0)
       Key: Usage
       Value: test-temp
 
@@ -663,7 +663,7 @@ jobs:
       ConnectedServiceName: $(ConnectedServiceName)
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
-      resourceGroupName: BakingDP-w16d150$(VersionText-w16d-15-0)$(Build.BuildNumber)
+      resourceGroupName: BakingDP-w16d150$(VersionText-w16d-15-0)
 
 - job: Job_3
   displayName: 'Agent job : w19d-14-2'
@@ -770,7 +770,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d-14-2$(VersionText-w19d-14-2 -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w19d-14-2$(VersionText-w19d-14-2)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -778,7 +778,7 @@ jobs:
     continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w19d142$(VersionText-w19d-14-2)$(Build.BuildNumber)
+      ResourceGroupName: BakingDP-w19d142$(VersionText-w19d-14-2)
       Key: Usage
       Value: test-temp
 
@@ -947,7 +947,7 @@ jobs:
     continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w19d150$(VersionText-w19d-15-0)$(Build.BuildNumber)
+      ResourceGroupName: BakingDP-w19d150$(VersionText-w19d-15-0)
       Key: Usage
       Value: test-temp
 
@@ -1001,7 +1001,7 @@ jobs:
       ConnectedServiceName: $(ConnectedServiceName)
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
-      resourceGroupName: BakingDP-w19d150$(VersionText-w19d-15-0)$(Build.BuildNumber)
+      resourceGroupName: BakingDP-w19d150$(VersionText-w19d-15-0)
 
 - job: Job_7
   displayName: 'Agent job : w16d-14-2j'
@@ -1116,7 +1116,7 @@ jobs:
     continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w16d142j$(VersionText-w16d-14-2j)$(Build.BuildNumber)
+      ResourceGroupName: BakingDP-w16d142j$(VersionText-w16d-14-2j)
       Key: Usage
       Value: test-temp
 
@@ -1170,7 +1170,7 @@ jobs:
       ConnectedServiceName: $(ConnectedServiceName)
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
-      resourceGroupName: BakingDP-w16d142j$(VersionText-w16d-14-2j)$(Build.BuildNumber)
+      resourceGroupName: BakingDP-w16d142j$(VersionText-w16d-14-2j)
 
 - job: Job_8
   displayName: 'Agent job : w16d-15-0j'
@@ -1285,7 +1285,7 @@ jobs:
     continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w16d150j$(VersionText-w16d-15-0j)$(Build.BuildNumber)
+      ResourceGroupName: BakingDP-w16d150j$(VersionText-w16d-15-0j)
       Key: Usage
       Value: test-temp
 
@@ -1339,8 +1339,7 @@ jobs:
       ConnectedServiceName: $(ConnectedServiceName)
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
-      resourceGroupName: BakingDP-w16d150j$(VersionText-w16d-15-0j)$(Build.BuildNumber)
-
+      resourceGroupName: BakingDP-w16d150j$(VersionText-w16d-15-0j)
 - job: Job_9
   displayName: 'Agent job : w19d-15-0j'
   timeoutInMinutes: 360
@@ -1454,7 +1453,7 @@ jobs:
     continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w19d150j$(VersionText-w19d-15-0j)$(Build.BuildNumber)
+      ResourceGroupName: BakingDP-w19d150j$(VersionText-w19d-15-0j)
       Key: Usage
       Value: test-temp
 
@@ -1508,7 +1507,7 @@ jobs:
       ConnectedServiceName: $(ConnectedServiceName)
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
-      resourceGroupName: BakingDP-w19d150j$(VersionText-w19d-15-0j)$(Build.BuildNumber)
+      resourceGroupName: BakingDP-w19d150j$(VersionText-w19d-15-0j)
 
 - job: Job_10
   displayName: 'Agent job : w19d-14-2j'
@@ -1623,7 +1622,7 @@ jobs:
     continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w19d142j$(VersionText-w19d-14-2j)$(Build.BuildNumber)
+      ResourceGroupName: BakingDP-w19d142j$(VersionText-w19d-14-2j)
       Key: Usage
       Value: test-temp
 
@@ -1677,7 +1676,7 @@ jobs:
       ConnectedServiceName: $(ConnectedServiceName)
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
-      resourceGroupName: BakingDP-w19d142j$(VersionText-w19d-14-2j)$(Build.BuildNumber)
+      resourceGroupName: BakingDP-w19d142j$(VersionText-w19d-14-2j)
 
 - job: Job_11
   displayName: 'Agent job : w22d-15-0j'
@@ -1792,7 +1791,7 @@ jobs:
     continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w22d150j$(VersionText-w22d-15-0j)$(Build.BuildNumber)
+      ResourceGroupName: BakingDP-w22d150j$(VersionText-w22d-15-0j)
       Key: Usage
       Value: test-temp
 
@@ -1846,7 +1845,7 @@ jobs:
       ConnectedServiceName: $(ConnectedServiceName)
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
-      resourceGroupName: BakingDP-w19d150j$(VersionText-w19d-15-0j)$(Build.BuildNumber)
+      resourceGroupName: BakingDP-w19d150j$(VersionText-w19d-15-0j)
 
 - job: Job_12
   displayName: 'Agent job : w22d-14-2j'
@@ -1961,7 +1960,7 @@ jobs:
     continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
-      ResourceGroupName: BakingDP-w22d142j$(VersionText-w22d-14-2j)$(Build.BuildNumber)
+      ResourceGroupName: BakingDP-w22d142j$(VersionText-w22d-14-2j)
       Key: Usage
       Value: test-temp
 
@@ -2015,5 +2014,5 @@ jobs:
       ConnectedServiceName: $(ConnectedServiceName)
       subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
       action: DeleteRG
-      resourceGroupName: BakingDP-w22d142j$(VersionText-w22d-14-2j)$(Build.BuildNumber)
+      resourceGroupName: BakingDP-w22d142j$(VersionText-w22d-14-2j)
 ...

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -15,9 +15,9 @@ variables:
   - group: 'Image Names'
   - group: 'Azure Logins'
   - name: atomic-build
-    value: $false
+    value: $False
   - name: atomic-build-ps
-    value: $false
+    value: $False
   - name: azureUserId
     value: PowershellScriptsSP
   - name:  Build-all

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -10,12 +10,7 @@ resources:
     type: git
     ref: refs/heads/debug/paas
 
-jobs:
-- job: Job_1
-  displayName: 'Agent job : w12r2d-14-2'
-  timeoutInMinutes: 120
-  condition: and(succeeded(), or(eq(variables['Build-w12r2d-14-2'], 'True'), eq(variables['Build-all'], 'True')))
-  variables: 
+variables: 
   - group: 'External IP Addresses'
   - group: 'Image Names'
   - group: 'Azure Logins'
@@ -24,29 +19,29 @@ jobs:
   - name: atomic-build-ps
     value: false
   - name: azureUserId
-    value: LPC-AsBake
+    value: PowershellScriptsSP
   - name:  Build-all
-    value: False
+    value: false
   - name: Build-w12r2d-14-2
-    value: True
+    value: true
   - name: Build-w12r2d-15-0
-    value: False
+    value: false
   - name: Build-w16d-14-2
-    value: False
+    value: false
   - name: Build-w16d-14-2j
-    value: False
+    value: false
   - name: Build-w16d-15-0
-    value: False
+    value: false
   - name: Build-w16d-15-0j
-    value: False
+    value: false
   - name: Build-w19d-14-2
-    value: False
+    value: false
   - name: Build-w19d-14-2j
-    value: False
+    value: false
   - name: Build-w19d-15-0
-    value: True
+    value: false
   - name: Build-w19d-15-0j
-    value: False
+    value: false
   # - name: clientsecret
     # value: ********
   - name: GitBranch
@@ -80,6 +75,13 @@ jobs:
   - name: ConnectedServiceName
     value: $(ConnectedServiceName)
 
+jobs:
+- job: Job_1
+  displayName: 'Agent job : w12r2d-14-2'
+  timeoutInMinutes: 120
+  condition: and(succeeded(), or(eq(variables['Build-w12r2d-14-2'], 'true'), eq(variables['Build-all'], 'true')))
+
+
   pool:
     vmImage: windows-2019
     
@@ -102,7 +104,7 @@ jobs:
 
         Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
 
-        if ($Env:PsModuleInstalled -eq 'True') {
+        if ($Env:PsModuleInstalled -eq 'true') {
             Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
             return;
         }
@@ -167,7 +169,7 @@ jobs:
         Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
 
 
-        $Env:PsModuleInstalled = 'True'
+        $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
   - task: PowerShell@2
     name: ''
@@ -244,7 +246,7 @@ jobs:
 - job: Job_5
   displayName: 'Agent job : w12r2d-15-0'
   timeoutInMinutes: 360
-  condition: and(succeeded(), or(eq(variables['Build-w12r2d-15-0'], 'True'), eq(variables['Build-all'], 'True')))
+  condition: and(succeeded(), or(eq(variables['Build-w12r2d-15-0'], 'true'), eq(variables['Build-all'], 'true')))
   pool:
     vmImage: windows-2019
   steps:
@@ -265,7 +267,7 @@ jobs:
 
         Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
 
-        if ($Env:PsModuleInstalled -eq 'True') {
+        if ($Env:PsModuleInstalled -eq 'true') {
             Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
             return;
         }
@@ -330,7 +332,7 @@ jobs:
         Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
 
 
-        $Env:PsModuleInstalled = 'True'
+        $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
   - task: PowerShell@2
     displayName: Azure Login
@@ -348,7 +350,7 @@ jobs:
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
-    continueOnError: True
+    continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
       ResourceGroupName: BakingDP-w12r2d150$(VersionText-w12r2d-15-0)$(Build.BuildNumber)
@@ -404,7 +406,7 @@ jobs:
 - job: Job_6
   displayName: 'Agent job : w16d-14-2'
   timeoutInMinutes: 360
-  condition: and(succeeded(), or(eq(variables['Build-w16d-14-2'], 'True'), eq(variables['Build-all'], 'True')))
+  condition: and(succeeded(), or(eq(variables['Build-w16d-14-2'], 'true'), eq(variables['Build-all'], 'true')))
   pool:
     vmImage: windows-2019
   steps:
@@ -425,7 +427,7 @@ jobs:
 
         Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
 
-        if ($Env:PsModuleInstalled -eq 'True') {
+        if ($Env:PsModuleInstalled -eq 'true') {
             Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
             return;
         }
@@ -490,7 +492,7 @@ jobs:
         Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
 
 
-        $Env:PsModuleInstalled = 'True'
+        $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
   - task: PowerShell@2
     displayName: Azure Login
@@ -508,7 +510,7 @@ jobs:
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
-    continueOnError: True
+    continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
       ResourceGroupName: BakingDP-w16d142$(VersionText-w16d-14-2)$(Build.BuildNumber)
@@ -564,7 +566,7 @@ jobs:
 - job: Job_4
   displayName: 'Agent job : w16d-15-0'
   timeoutInMinutes: 360
-  condition: and(succeeded(), or(eq(variables['Build-w16d-15-0'], 'True'), eq(variables['Build-all'], 'True')))
+  condition: and(succeeded(), or(eq(variables['Build-w16d-15-0'], 'true'), eq(variables['Build-all'], 'true')))
   pool:
     vmImage: windows-2019
   steps:
@@ -585,7 +587,7 @@ jobs:
 
         Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
 
-        if ($Env:PsModuleInstalled -eq 'True') {
+        if ($Env:PsModuleInstalled -eq 'true') {
             Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
             return;
         }
@@ -650,7 +652,7 @@ jobs:
         Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
 
 
-        $Env:PsModuleInstalled = 'True'
+        $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
   - task: PowerShell@2
     displayName: Azure Login
@@ -668,7 +670,7 @@ jobs:
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
-    continueOnError: True
+    continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
       ResourceGroupName: BakingDP-w16d150$(VersionText-w16d-15-0)$(Build.BuildNumber)
@@ -724,7 +726,7 @@ jobs:
 - job: Job_3
   displayName: 'Agent job : w19d-14-2'
   timeoutInMinutes: 360
-  condition: and(succeeded(), or(eq(variables['Build-w19d-14-2'], 'True'), eq(variables['Build-all'], 'True')))
+  condition: and(succeeded(), or(eq(variables['Build-w19d-14-2'], 'true'), eq(variables['Build-all'], 'true')))
   pool:
     vmImage: windows-2019
   steps:
@@ -745,7 +747,7 @@ jobs:
 
         Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
 
-        if ($Env:PsModuleInstalled -eq 'True') {
+        if ($Env:PsModuleInstalled -eq 'true') {
             Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
             return;
         }
@@ -810,7 +812,7 @@ jobs:
         Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
 
 
-        $Env:PsModuleInstalled = 'True'
+        $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
   - task: PowerShell@2
     displayName: Azure Login
@@ -828,7 +830,7 @@ jobs:
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
-    continueOnError: True
+    continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
       ResourceGroupName: BakingDP-w19d142$(VersionText-w19d-14-2)$(Build.BuildNumber)
@@ -884,7 +886,7 @@ jobs:
 - job: Job_2
   displayName: 'Agent job : w19d-15-0'
   timeoutInMinutes: 360
-  condition: and(succeeded(), or(eq(variables['Build-w19d-15-0'], 'True'), eq(variables['Build-all'], 'True')))
+  condition: and(succeeded(), or(eq(variables['Build-w19d-15-0'], 'true'), eq(variables['Build-all'], 'true')))
   pool:
     vmImage: windows-2019
   steps:
@@ -905,7 +907,7 @@ jobs:
 
         Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
 
-        if ($Env:PsModuleInstalled -eq 'True') {
+        if ($Env:PsModuleInstalled -eq 'true') {
             Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
             return;
         }
@@ -970,7 +972,7 @@ jobs:
         Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
 
 
-        $Env:PsModuleInstalled = 'True'
+        $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
   - task: PowerShell@2
     displayName: Azure Login
@@ -988,7 +990,7 @@ jobs:
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
-    continueOnError: True
+    continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
       ResourceGroupName: BakingDP-w19d150$(VersionText-w19d-15-0)$(Build.BuildNumber)
@@ -1044,7 +1046,7 @@ jobs:
 - job: Job_7
   displayName: 'Agent job : w16d-14-2j'
   timeoutInMinutes: 360
-  condition: and(succeeded(), or(eq(variables['Build-w16d-14-2j'], 'True'), eq(variables['Build-all'], 'True')))
+  condition: and(succeeded(), or(eq(variables['Build-w16d-14-2j'], 'true'), eq(variables['Build-all'], 'true')))
   pool:
     vmImage: windows-2019
   steps:
@@ -1065,7 +1067,7 @@ jobs:
 
         Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
 
-        if ($Env:PsModuleInstalled -eq 'True') {
+        if ($Env:PsModuleInstalled -eq 'true') {
             Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
             return;
         }
@@ -1130,7 +1132,7 @@ jobs:
         Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
 
 
-        $Env:PsModuleInstalled = 'True'
+        $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
   - task: PowerShell@2
     displayName: Azure Login
@@ -1148,7 +1150,7 @@ jobs:
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
-    continueOnError: True
+    continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
       ResourceGroupName: BakingDP-w16d142j$(VersionText-w16d-14-2j)$(Build.BuildNumber)
@@ -1204,7 +1206,7 @@ jobs:
 - job: Job_8
   displayName: 'Agent job : w16d-15-0j'
   timeoutInMinutes: 360
-  condition: and(succeeded(), or(eq(variables['Build-w16d-15-0j'], 'True'), eq(variables['Build-all'], 'True')))
+  condition: and(succeeded(), or(eq(variables['Build-w16d-15-0j'], 'true'), eq(variables['Build-all'], 'true')))
   pool:
     vmImage: windows-2019
   steps:
@@ -1225,7 +1227,7 @@ jobs:
 
         Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
 
-        if ($Env:PsModuleInstalled -eq 'True') {
+        if ($Env:PsModuleInstalled -eq 'true') {
             Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
             return;
         }
@@ -1290,7 +1292,7 @@ jobs:
         Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
 
 
-        $Env:PsModuleInstalled = 'True'
+        $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
   - task: PowerShell@2
     displayName: Azure Login
@@ -1308,7 +1310,7 @@ jobs:
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
-    continueOnError: True
+    continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
       ResourceGroupName: BakingDP-w16d150j$(VersionText-w16d-15-0j)$(Build.BuildNumber)
@@ -1364,7 +1366,7 @@ jobs:
 - job: Job_9
   displayName: 'Agent job : w19d-15-0j'
   timeoutInMinutes: 360
-  condition: and(succeeded(), or(eq(variables['Build-w19d-15-0j'], 'True'), eq(variables['Build-all'], 'True')))
+  condition: and(succeeded(), or(eq(variables['Build-w19d-15-0j'], 'true'), eq(variables['Build-all'], 'true')))
   pool:
     vmImage: windows-2019
   steps:
@@ -1385,7 +1387,7 @@ jobs:
 
         Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
 
-        if ($Env:PsModuleInstalled -eq 'True') {
+        if ($Env:PsModuleInstalled -eq 'true') {
             Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
             return;
         }
@@ -1450,7 +1452,7 @@ jobs:
         Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
 
 
-        $Env:PsModuleInstalled = 'True'
+        $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
   - task: PowerShell@2
     displayName: Azure Login
@@ -1468,7 +1470,7 @@ jobs:
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
-    continueOnError: True
+    continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
       ResourceGroupName: BakingDP-w19d150j$(VersionText-w19d-15-0j)$(Build.BuildNumber)
@@ -1524,7 +1526,7 @@ jobs:
 - job: Job_10
   displayName: 'Agent job : w19d-14-2j'
   timeoutInMinutes: 360
-  condition: and(succeeded(), or(eq(variables['Build-w19d-14-2j'], 'True'), eq(variables['Build-all'], 'True')))
+  condition: and(succeeded(), or(eq(variables['Build-w19d-14-2j'], 'true'), eq(variables['Build-all'], 'true')))
   pool:
     vmImage: windows-2019
   steps:
@@ -1545,7 +1547,7 @@ jobs:
 
         Write-Host "##vso[task.setvariable variable=GitBranch]$branch" | Out-Default | Write-Verbose
 
-        if ($Env:PsModuleInstalled -eq 'True') {
+        if ($Env:PsModuleInstalled -eq 'true') {
             Write-Host "PS Module already installed, skip the Install PS Module Task." | Out-Default | Write-Verbose
             return;
         }
@@ -1610,7 +1612,7 @@ jobs:
         Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
 
 
-        $Env:PsModuleInstalled = 'True'
+        $Env:PsModuleInstalled = 'true'
       errorActionPreference: continue
   - task: PowerShell@2
     displayName: Azure Login
@@ -1628,7 +1630,7 @@ jobs:
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging
-    continueOnError: True
+    continueOnError: true
     inputs:
       ConnectedServiceName: $(ConnectedServiceName)
       ResourceGroupName: BakingDP-w19d142j$(VersionText-w19d-14-2j)$(Build.BuildNumber)

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -18,6 +18,7 @@ jobs:
   variables: 
   - group: 'External IP Addresses'
   - group: 'Image Names'
+  - group: 'Azure Logins'
   - name: atomic-build
     value: false
   - name: atomic-build-ps

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -92,7 +92,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w22d-14-2$(VersionText-w22d-14-2)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -GitUserName $(GitUserName) -ExternalIPAddresses $(ExternalIPAddresses)
+      arguments: -VersionText 'w22d-14-2$(VersionText-w22d-14-2)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2022-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses $(ExternalIPAddresses)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -263,7 +263,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w22d-15-0$(VersionText-w22d-15-0)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2012-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w22d-15-0$(VersionText-w22d-15-0)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2022-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -432,7 +432,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w16d-14-2$(VersionText-w16d-14-2)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2016-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w16d-14-2$(VersionText-w16d-14-2)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2016-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -601,7 +601,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w16d-15-0$(VersionText-w16d-15-0)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2016-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w16d-15-0$(VersionText-w16d-15-0)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2016-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -770,7 +770,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d-14-2$(VersionText-w19d-14-2)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w19d-14-2$(VersionText-w19d-14-2)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -939,7 +939,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d-15-0$(VersionText-w19d-15-0)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w19d-15-0$(VersionText-w19d-15-0)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -1108,7 +1108,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w16d-14-2j$(VersionText-w16d-14-2j)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2016-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w16d-14-2j$(VersionText-w16d-14-2j)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2016-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -1277,7 +1277,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w16d-15-0j$(VersionText-w16d-15-0j)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2016-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w16d-15-0j$(VersionText-w16d-15-0j)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2016-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -1445,7 +1445,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d-15-0j$(VersionText-w19d-15-0j)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w19d-15-0j$(VersionText-w19d-15-0j)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -1614,7 +1614,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w19d-14-2j$(VersionText-w19d-14-2j)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName  $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w19d-14-2j$(VersionText-w19d-14-2j)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName  $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -1783,7 +1783,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w22d-15-0j$(VersionText-w22d-15-0j)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2022-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w22d-15-0j$(VersionText-w22d-15-0j)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2022-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
@@ -1952,7 +1952,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w22d-14-2j$(VersionText-w22d-14-2j)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName  $(Windows-2019-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
+      arguments: -VersionText 'w22d-14-2j$(VersionText-w22d-14-2j)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName  $(Windows-2022-IMAGE-URI-JPN) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -GitUserName $(GitUserName) -MaxRetry $(MaxRetry) -ExternalIPAddresses  $(ExternalIPAddresses) -Language $(JpnLanguage) -InstallLanguagePack
       workingDirectory: scripts
 
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1

--- a/Azure Images - Cookbooks CI 3.0.yml
+++ b/Azure Images - Cookbooks CI 3.0.yml
@@ -192,7 +192,7 @@ jobs:
     timeoutInMinutes: 120
     inputs:
       filePath: scripts/bake-scalable-azure-image-pipeline.ps1
-      arguments: -VersionText 'w22d142$(VersionText-w22d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -AmazonAMIName $(Windows-2022-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
+      arguments: -VersionText 'w22d142$(VersionText-w22d-14-2)$(Build.BuildNumber)' -VersionMajor 14 -VersionMinor 2 -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $true -AtomicBuild variables['atomic-build-ps'] -GitUserName $(GitUserName) -ExternalIPAddresses  $(ExternalIPAddresses)
       workingDirectory: scripts
   - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
     displayName: Azure Resource Group Tagging

--- a/Templates/releaseTemplate.yml
+++ b/Templates/releaseTemplate.yml
@@ -1,0 +1,186 @@
+parameters:
+  - name: stageName
+    type: string
+    default: none
+  - name: stageDisplayname
+    type: string
+    default: none
+  - name: runStage
+    type: boolean
+    default: true
+  # - name: dependsOn
+  #   default: []
+  - name: jobName
+    type: string
+    default: none
+  - name: jobDisplayname
+    type: string
+    default: none
+  - name: vmImage
+    type: string
+    default: windows-2022
+  - name: jobcondition
+    type: string
+    default: ''
+  - name: jobDemand
+    type: string
+    default: ''
+
+    stages:
+      - stage: ${{ parameters.stageName }}
+        condition: ${{ parameters.runStage }}
+        dependsOn: []
+        displayName: ${{ parameters.stageDisplayname }}
+        jobs:
+        - job: ${{ parameters.jobName }}
+          timeoutInMinutes: 0
+          cancelTimeoutInMinutes: 1
+          condition: ${{ parameters. jobcondition}}
+          displayName: ${{ parameters.jobDisplayname }}
+
+          variables:
+            TemplateS3Namespace: '/image-cd-pipeline'
+
+          pool:
+            vmImage: ${{ parameters.vmImage }}
+            demands: ${{ parameters.jobDemand }}
+
+          steps:
+          - download: _BuildCloudAccountIdArtefacts
+            displayName: Download artifacts from Build Cloud Account Id Artefacts
+
+          - download: _BuildImageReleaseArtefacts
+            displayName: Download artifacts from Build Image Release Artefacts 2.0
+
+          - checkout: self
+
+          - checkout: _LansaAWSTemplates
+            displayName: Checkout nkhl-accolite/aws-templates-nkhl
+
+          - checkout: _Robe070Cookbooks
+            displayName: Checkout nkhl-accolite/cookbooks
+
+          - task: PowerShell@2
+            displayName: 'Artifact Check : Set Gate Variable'
+            inputs:
+              targetType: filePath
+              filePath: './$(System.DefaultWorkingDirectory)/_robe070_cookbooks/scripts/azure_set_gate_variable_cloud_account_id.ps1'
+              arguments: '-Version "$(System.JobDisplayName)" -osName "Windows Server 2019"'
+              
+          #Your build pipeline references an undefined variable named ‘Gate.IsEnabled’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+          #Your build pipeline references an undefined variable named ‘Gate.Version’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+          #Your build pipeline references an undefined variable named ‘Gate.VersionClean’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+          #Your build pipeline references an undefined variable named ‘Gate.ImageUrl’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+          #Your build pipeline references an undefined variable named ‘Gate.osName’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+          #Your build pipeline references an undefined variable named ‘Gate.Sku’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+
+          - powershell: |
+            # Print the Gate variables.
+            Write-Host "Gate.IsEnabled: $(Gate.IsEnabled)"
+            Write-Host "Gate.Version: $(Gate.Version)"
+            Write-Host "Gate.VersionClean: $(Gate.VersionClean)"
+            Write-Host "Gate.ImageUrl: $(Gate.ImageUrl)"
+            Write-Host "Gate.osName: $(Gate.osName)"
+            Write-Host "Gate.Sku: $(Gate.Sku)"
+            
+            displayName: 'Artifact Check : Output Gate Variable'
+            condition: and(succeeded(), eq(variables['Gate.IsEnabled'], 'True'))
+
+          - task: AzurePowerShell@5
+        displayName: 'Delete Resource Group'
+        inputs:
+          azureSubscription: 'Azure Baking Images'
+          ScriptType: InlineScript
+          Inline: |
+          Write-Host "Deleting Resource Group $(Gate.StackName)"
+          Remove-AzResourceGroup -Name $(Gate.StackName) -Force
+          errorActionPreference: silentlyContinue
+          azurePowerShellVersion: LatestVersion
+        condition: and(succeeded(), eq(variables['Gate.IsEnabled'], 'True'))
+
+          #Your build pipeline references an undefined variable named ‘Gate.StackName’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+    #Your build pipeline references an undefined variable named ‘Gate.osName’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+    #Your build pipeline references an undefined variable named ‘Gate.ImageUrl’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+    #Your build pipeline references an undefined variable named ‘msiURLv15’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+    #Your build pipeline references an undefined variable named ‘Gate.VersionClean’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+    #Your build pipeline references an undefined variable named ‘certificateBase64Encoded’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+    #Your build pipeline references an undefined variable named ‘certificatePassword’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+    #Your build pipeline references an undefined variable named ‘databaseLogin’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+    #Your build pipeline references an undefined variable named ‘databaseLoginPassword’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+    #Your build pipeline references an undefined variable named ‘adminUsername’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+    #Your build pipeline references an undefined variable named ‘adminPassword’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+    #Your build pipeline references an undefined variable named ‘webUsername’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+    #Your build pipeline references an undefined variable named ‘webPassword’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+
+    steps:
+    - task: AzureResourceManagerTemplateDeployment@3
+      displayName: 'Deploy ARM Template '
+      inputs:
+        azureResourceManagerConnection: 
+        subscriptionId: '739c4e86-bd75-4910-8d6e-d7eb23ab94f3'
+        resourceGroupName: '$(Gate.StackName)'
+        location: 'Australia East'
+        csmFile: '$(System.DefaultWorkingDirectory)/_lansa_azure-quickstart-templates/lansa-vmss-windows-autoscale-sql-database/mainTemplate.json'
+        overrideParameters: '-osName "$(Gate.osName)" -lansaVersion "V15 GA" -imageId "$(Gate.ImageUrl)" -imageSource "Custom" -msiURL $(msiURLv15) -stackName "$(Gate.VersionClean)" -certificateBase64Encoded "$(certificateBase64Encoded)" -certificatePassword "$(certificatePassword)" -databaseLogin "$(databaseLogin)" -databaseLoginPassword "$(databaseLoginPassword)" -adminUsername "$(adminUsername)" -adminPassword "$(adminPassword)" -webUsername "$(webUsername)" -webPassword "$(webPassword)" -gitBranch "debug/paas"'
+        deploymentName: CustomTestTemplate
+        deploymentOutputs: deploymentOutput
+        addSpnToEnvironment: true
+      condition: and(succeeded(), eq(variables['Gate.IsEnabled'], 'True'))
+
+        
+    - task: AzureResourceManagerTemplateDeployment@3
+      displayName: 'Deploy ARM Template '
+      inputs:
+        azureResourceManagerConnection: 'Azure Baking Images'
+        subscriptionId: '739c4e86-bd75-4910-8d6e-d7eb23ab94f3'
+        resourceGroupName: '$(Gate.StackName)'
+        location: 'Australia Southeast'
+        csmFile: '$(System.DefaultWorkingDirectory)/_lansa_azure-quickstart-templates/lansa-vmss-windows-autoscale-sql-database/mainTemplate.json'
+        overrideParameters: '-osName "$(Gate.osName)" -lansaVersion "V15 GA" -imageId "$(Gate.ImageUrl)" -imageSource "Custom" -msiURL $(msiURLv15) -stackName "$(Gate.VersionClean)" -certificateBase64Encoded "$(certificateBase64Encoded)" -certificatePassword "$(certificatePassword)" -databaseLogin "$(databaseLogin)" -databaseLoginPassword "$(databaseLoginPassword)" -adminUsername "$(adminUsername)" -adminPassword "$(adminPassword)" -webUsername "$(webUsername)" -webPassword "$(webPassword)" -gitBranch "debug/paas"'
+        deploymentName: CustomTestTemplate
+        deploymentOutputs: deploymentOutput
+        addSpnToEnvironment: true
+      condition: and(succeeded(), eq(variables['Gate.IsEnabled'], 'True'))
+
+          
+    - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
+      displayName: 'Azure Resource Group Tagging'
+      inputs:
+        ConnectedServiceName: 'Azure Baking Images'
+        ResourceGroupName: '$(Gate.StackName)'
+        Key: Usage
+        Value: 'test-temp'
+      continueOnError: true
+      condition: and(succeeded(), eq(variables['Gate.IsEnabled'], 'True'))
+      
+        #Your build pipeline references an undefined variable named ‘deploymentOutput’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+
+    - powershell: |
+      # Print the Deployment Output
+      Write-Host "$(deploymentOutput)" | out-default | Write-Verbose
+      displayName: 'Print Deployment Output'
+      condition: and(succeeded(), eq(variables['Gate.IsEnabled'], 'True'))
+
+      #Your build pipeline references an undefined variable named ‘deploymentOutput’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+
+    - task: PowerShell@2
+      displayName: 'Test ARM Deployment : URL Tests'
+      inputs:
+        targetType: filePath
+        filePath: './$(System.DefaultWorkingDirectory)/_robe070_cookbooks/scripts/azure_url_tests.ps1'
+        arguments: '-deploymentOutput ''$(deploymentOutput)'''
+      condition: and(succeeded(), eq(variables['Gate.IsEnabled'], 'True'))
+
+      #Your build pipeline references an undefined variable named ‘Gate.StackName’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+
+    steps:
+    - task: AzureResourceManagerTemplateDeployment@3
+      displayName: 'Delete Resource Group'
+      inputs:
+        azureResourceManagerConnection: 
+        subscriptionId: '739c4e86-bd75-4910-8d6e-d7eb23ab94f3'
+        action: DeleteRG
+        resourceGroupName: '$(Gate.StackName)'
+      continueOnError: true
+      condition: and(succeeded(), eq(variables['Gate.IsEnabled'], 'True'))
+      timeoutInMinutes: 240

--- a/scripts/bake-ide-ami.ps1
+++ b/scripts/bake-ide-ami.ps1
@@ -672,7 +672,6 @@ $jsonObject = @"
             # Ensure last exit code is 0. (exit by itself will terminate the remote session)
             cmd /c exit 0
         }
-
         # Load up some required tools into remote environment
 
         # Load basic utils before running anything
@@ -680,21 +679,62 @@ $jsonObject = @"
 
 
         if ( $InstallBaseSoftware ) {
-
+            
             # Install Chocolatey
-
             Execute-RemoteScript -Session $Script:session -FilePath "$script:IncludeDir\getchoco.ps1"
 
-            # Then we install git using chocolatey and pull down the rest of the files from git
+            if ( $Cloud -eq 'Azure' ) {
+                Write-Host("$(Log-Date) Azure requires a reboot after installing choco. Rebooting now..")
+                
+                Execute-RemoteBlock $Script:session {
+                    Restart-Computer -force
+                }
+                Start-Sleep -Seconds 10
+            
+                Write-Host "$(Log-Date) Reconnecting session..."
+                if ( $Script:session ) { Remove-PSSession $Script:session | Out-Default | Write-Host }
+            
+                Connect-RemoteSession | Out-Default | Write-Host
+                Invoke-Command -Session $Script:session {Set-ExecutionPolicy Unrestricted -Scope CurrentUser}
+                $remotelastexitcode = invoke-command  -Session $Script:session -ScriptBlock { $lastexitcode}
+                if ( $remotelastexitcode -and $remotelastexitcode -ne 0 ) {
+                    Write-Error "LastExitCode: $remotelastexitcode"
+                    throw 1
+                }
+                Execute-RemoteInit | Out-Default | Write-Host
+                Execute-RemoteScript -Session $Script:session -FilePath "$script:IncludeDir\dot-CommonTools.ps1"
+                Write-host "$(Log-Date) The VM is now rebooted."
+            }
+            
 
+            # Then we install git using chocolatey and pull down the rest of the files from git
+            Write-Host "Installing Git!"
+            # if ( $Cloud -eq 'Azure' ) {
+                
+            #     Invoke-Command -Session $Script:session {Set-ExecutionPolicy Unrestricted -Scope CurrentUser}
+            #     $remotelastexitcode = invoke-command  -Session $Script:session -ScriptBlock { $lastexitcode}
+            #     if ( $remotelastexitcode -and $remotelastexitcode -ne 0 ) {
+            #         Write-Error "LastExitCode: $remotelastexitcode"
+            #         throw 1
+            #     }
+            # }
             Execute-RemoteScript -Session $Script:session -FilePath $script:IncludeDir\installGit.ps1 -ArgumentList  @($Script:GitRepo, $Script:GitRepoPath, $GitBranch, $GitUserName, $true)
 
             Execute-RemoteBlock $Script:session { "Path = $([Environment]::GetEnvironmentVariable('PATH', 'Machine'))" | Out-Default | Write-Host }
+
 
             # Load utilities into Remote Session.
             # Requires the git repo to be pulled down so the scripts are present and the script variables initialised with Init-Baking-Vars.ps1.
             # Reflect local variables into remote session
             Execute-RemoteInitPostGit
+            
+            if ( $Cloud -eq 'Azure' ) {
+                Write-Host "Installing .Net!"
+                . "$script:IncludeDir\Init-Baking-Vars.ps1"
+                . "$script:IncludeDir\Init-Baking-Includes.ps1"
+                . "$script:IncludeDir\dot-CommonTools.ps1"
+            }
+
 
             # Upload files that are not in Git. Should be limited to secure files that must not be in Git.
             # Git is a far faster mechansim for transferring files than using RemotePS.

--- a/scripts/getchoco.ps1
+++ b/scripts/getchoco.ps1
@@ -32,6 +32,7 @@
 $url = ''
 
 try {
+    $env:chocolateyVersion = '1.4.0'
     $chocolateyVersion = $env:chocolateyVersion
     if (![string]::IsNullOrEmpty($chocolateyVersion)){
     Write-Host "Downloading specific version of Chocolatey: $chocolateyVersion"

--- a/scripts/install-lansa-base.ps1
+++ b/scripts/install-lansa-base.ps1
@@ -99,6 +99,9 @@ try
         New-Item $TempPath -type directory -ErrorAction SilentlyContinue | Out-Default | Write-Host
     }
 
+    #  Enabling TLS 1.2 security protocol to establsih a secure connection with the server when making web requests.
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
     $Cloud = (Get-ItemProperty -Path HKLM:\Software\LANSA  -Name 'Cloud').Cloud
     $InstallSQLServer = $false
     $InstallSQLServer = (Get-ItemProperty -Path HKLM:\Software\LANSA  -Name 'InstallSQLServer' -ErrorAction SilentlyContinue).InstallSQLServer

--- a/scripts/install-powershell-modules-azure.ps1
+++ b/scripts/install-powershell-modules-azure.ps1
@@ -39,8 +39,8 @@ Install-Module -Name Az -RequiredVersion 4.5.0 -AllowClobber -Force | Out-Defaul
 Write-Host "Installed Module Az -RequiredVersion 4.5.0" | Out-Default | Write-Verbose
 
 # Pester for Testing
-Write-Host "Installing Module Pester RequiredVersion 5.0.3" | Out-Default | Write-Verbose
-Install-Module -Name Pester -RequiredVersion 5.0.3 -AllowClobber -Force
+Write-Host "Installing Module Pester RequiredVersion 5.6.1" | Out-Default | Write-Verbose
+Install-Module -Name Pester -RequiredVersion 5.6.1 -AllowClobber -Force
 Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
 
 $Env:PsModuleInstalled = 'True'

--- a/scripts/install-powershell-modules.ps1
+++ b/scripts/install-powershell-modules.ps1
@@ -10,8 +10,8 @@ if ($Env:PsModuleInstalled -eq 'True') {
     return;
 }
 # Pester for Testing
-Write-Host "Installing Module Pester RequiredVersion 5.0.3" | Out-Default | Write-Verbose
-Install-Module -Name Pester -RequiredVersion 5.0.3 -AllowClobber -Force
+Write-Host "Installing Module Pester RequiredVersion 5.6.1" | Out-Default | Write-Verbose
+Install-Module -Name Pester -RequiredVersion 5.6.1 -AllowClobber -Force
 Write-Host "Installed Module Pester" | Out-Default | Write-Verbose
 
 $Env:PsModuleInstalled = 'True'


### PR DESCRIPTION
Converted classic pipeline to YAML pipeline, details are below:

Classic pipeline: -
repository: https://github.com/robe070/cookbooks/compare/debug/paas...priyadishah:cookbooks:feature/priyanka-classic2YAML?expand=1
branch: debug/paas
pipeline name: Azure Images - Cookbooks CI 

Converted classic to YAML pipeline:
repository: priyadishah/cookbooks
branch: feature/priyanka-classic2YAML
pipeline name: Azure Images - Cookbooks CI 3.0
pipeline url: 
https://dev.azure.com/VisualLansa/Lansa%20Azure%20Scalable%20License%20Images/_build/results?buildId=2136&view=logs&j=275f1d19-1bd8-5591-b06b-07d489ea915a

1. D:\a\1\s\scripts\bake-scalable-azure-image-pipeline.ps1 : Cannot process argument transformation on parameter
'AtomicBuild'. Cannot convert value "System.String" to type "System.Boolean". Boolean parameters accept only Boolean
values and numbers, such as $True, $False, 1 or 0.
At D:\a\_temp\7ee5fe9a-44de-4c66-8aec-365c7576a9a1.ps1:4 char:238
+ ... ud 'Azure' -Win2012 $true -AtomicBuild ${env:ATOMIC-BUILD-PS} -GitUse ...
+                                            ~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidData: (:) [bake-scalable-azure-image-pipeline.ps1], ParentContainsErrorRecordExce
   ption
We changed ${env:ATOMIC-BUILD-PS} to $(atomic-build-ps)

2. We encountered error in build: Image bake failed. Retry not enabled in Azure. For which we have replaced script, bake-ide-ami.ps1 and it fixed the error. Installed choclateyVersion = '1.4.0'
3. After which we got error in Azure Resource Group: Provided resource group does not exist. 2024-09-25T06:30:42.7141497Z ##[debug]INPUT_ACTION: 'Add'
2024-09-25T06:30:42.7148823Z Resource group: BakingDP-w22d1420Azure-Images-Cookbooks-CI-3.0-2017
For which replaced the resource group to BakingDP-w19d-14-2-$(VersionText-w19d-14-2) and fixed error.
4. Error in Delete Resource Group: Changed the resource group again to BakingDP-w19d-14-2-$(VersionText-w19d-14-2) and fixed error.





