### PR TITLE
Conversion of classic pipeline to YAML (`Build Cloud Account Id Artefacts` to `Build Cloud Account Id Artefacts 3.0`)

### DIFF
--- a/Azure-Build-Cloud-Account-Id-Artefacts.yml
+++ b/Azure-Build-Cloud-Account-Id-Artefacts.yml
@@ -1,0 +1,107 @@
+name: Build-Cloud-Account-Id-Artefacts-$(Build.BuildId)
+
+trigger: none
+
+pr: none
+
+jobs:
+- job: w19d_15_ID
+  displayName: w19d-15-ID
+  timeoutInMinutes: 360
+  condition: and(succeeded(), or(eq(variables['Build-w19d-15-ID'], 'true'), eq(variables['Build-all'], 'true')))
+  
+  variables:
+  - group: 'External IP Addresses'
+  - group: 'Image Names'
+  - group: 'Azure Logins'
+  - name: azureUserId
+    value: PowershellScriptsSP
+  - name: GitBranchPR
+    value: 'debug/paas'
+  - name: JpnLanguage
+    value: JPN
+  - name: quickstart-scripts
+    value: '$(Agent.BuildDirectory)\test'
+
+  pool:
+    vmImage: windows-2019
+    
+  steps:
+  - checkout: self
+
+  - task: PowerShell@2
+    displayName: Install PS Module
+    condition: and(succeeded(), or(eq(variables['Build-w19d-15-ID'], 'true'), eq(variables['Build-all'], 'true')))
+    inputs:
+      filePath: scripts/install-powershell-modules-azure.ps1
+      errorActionPreference: continue
+
+  - task: PowerShell@2
+    displayName: Azure Login
+    inputs:
+      filePath: scripts/AzureLogin.ps1
+      arguments: -CloudAccount $(azureUserId) -CloudSecret $(ConvertTo-SecureString $(clientSecret) -AsPlainText -force)
+      workingDirectory: scripts
+
+  - task: PowerShell@2
+    name: BuildImage
+    displayName: Build Image
+    timeoutInMinutes: 120
+    inputs:
+      filePath: scripts/bake-scalable-azure-image-pipeline.ps1
+      arguments: -VersionText '$(System.JobDisplayName)' -VersionMajor 15 -VersionMinor 0 -AmazonAMIName $(Windows-2019-IMAGE-NAME) -GitBranch "$(GitBranch)" -Cloud 'Azure' -Win2012 $false -ExternalIPAddresses  $(ExternalIPAddresses) -CloudAccountLicense 'x_lic_AZR*.5.lic' -MaxRetry $(MaxRetry)
+      workingDirectory: scripts
+
+  - task: maikvandergaag.maikvandergaag-azurergtag.azurergtag.azurergtag@1
+    displayName: Azure Resource Group Tagging
+    continueOnError: true
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      ResourceGroupName: BakingDP-$(System.JobDisplayName)
+      Key: Usage
+      Value: test-temp
+
+  - task: PowerShell@2
+    displayName: 'Generate: Image URL'
+    inputs:
+      targetType: inline
+      script: >-
+        Write-Host "Writing the Full Image URL $(BuildImage.ImageUrl) in the $(Build.ArtifactStagingDirectory)" | Out-Default | Write-Host
+
+        Out-File -FilePath (Join-Path $(Build.ArtifactStagingDirectory) "$(System.JobDisplayName).txt") -InputObject $(BuildImage.ImageUrl) | Out-Default | Write-Host
+
+        Write-Host "Full Image URL written successfully" | Out-Default | Write-Host
+
+  - task: PowerShell@2
+    displayName: 'VM Tests'
+    inputs:
+      targetType: filePath
+      filePath: './scripts/invoke-pester-tests.ps1'
+    env:
+      TestImageName: $(System.JobDisplayName)
+      TestCloudName: Azure
+      TestVmName: $(System.JobDisplayName)
+
+  - task: PublishTestResults@2
+    displayName: Publish Test Results **/Test-*.xml
+    name: Vmtest
+    inputs:
+      testRunner: NUnit
+      testResultsFiles: '**/Test-*.xml'
+      testRunTitle: $(System.JobDisplayName)
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: Image URL'
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)/$(System.JobDisplayName).txt
+      ArtifactName: $(System.JobDisplayName)
+      FileCopyOptions: ''
+
+  - task: AzureResourceManagerTemplateDeployment@3
+    displayName: Delete Resource Group
+    inputs:
+      ConnectedServiceName: $(ConnectedServiceName)
+      subscriptionName: 739c4e86-bd75-4910-8d6e-d7eb23ab94f3
+      action: DeleteRG
+      resourceGroupName: BakingDP-$(System.JobDisplayName)
+

--- a/scripts/azure_set_gate_variable.ps1
+++ b/scripts/azure_set_gate_variable.ps1
@@ -10,7 +10,8 @@ param (
 
 Write-Host "version is - $Version"
 # Set the Gate variable if the file exists
-$path = "$($env:System_DefaultWorkingDirectory)/_Lansa Images - Cookbooks/$Version/$Version.txt"
+$path = "$($env:Pipeline_Workspace)/_BuildImageReleaseArtefacts/$Version/$Version.txt"
+Write-Host "PATH = $path"
 if (Test-Path $path) {
     # Remove characters from Version so reduce length to less than 9 and which are not compatible with resource ids in the template.
     # In particular, the VM base name in a Scale Set

--- a/scripts/azure_set_gate_variable.ps1
+++ b/scripts/azure_set_gate_variable.ps1
@@ -10,8 +10,7 @@ param (
 
 Write-Host "version is - $Version"
 # Set the Gate variable if the file exists
-$path = "$($env:Pipeline_Workspace)/_BuildImageReleaseArtefacts/$Version/$Version.txt"
-Write-Host "PATH = $path"
+$path = "$($env:System_DefaultWorkingDirectory)/_Lansa Images - Cookbooks/$Version/$Version.txt"
 if (Test-Path $path) {
     # Remove characters from Version so reduce length to less than 9 and which are not compatible with resource ids in the template.
     # In particular, the VM base name in a Scale Set


### PR DESCRIPTION
Original pipeline: https://dev.azure.com/VisualLansa/Lansa%20Azure%20Scalable%20License%20Images/_build?definitionId=35

New pipeline: https://dev.azure.com/VisualLansa/Lansa%20Azure%20Scalable%20License%20Images/_build?definitionId=71

Changes:

0. The previous pipeline (https://dev.azure.com/VisualLansa/Lansa%20Azure%20Scalable%20License%20Images/_build?definitionId=44) has been renamed to `Build Cloud Account Id Artefacts 3.0 - OLD`.

1. Changed the name of the job
2. The service connection string to Azure was made a variable (called `ConnectedServiceName`)
3. Variable Group references were added, and appropriate variables also were added.
4. The Choco version to be installed was set to _1.4.0_, as the latest Choco wasn't being installed properly.
5. Introduced code to reboot the VM after Choco installation.